### PR TITLE
refactor(dcql): add processor extension point for credential type validation

### DIFF
--- a/oid4vc/mso_mdoc/cred_processor.py
+++ b/oid4vc/mso_mdoc/cred_processor.py
@@ -61,3 +61,24 @@ class MsoMdocCredProcessor(Issuer):
     def validate_supported_credential(self, supported: SupportedCredential):
         """Validate a supported MSO MDOC Credential."""
         pass
+
+    def format_data_is_top_level(self) -> bool:
+        """mso_mdoc format_data fields belong at the top level of credential config."""
+        return True
+
+    # COSE algorithm name → integer identifier mapping (RFC 8152 / IANA COSE registry)
+    _COSE_ALG: dict = {"ES256": -7, "ES384": -35, "ES512": -36, "ES256K": -47}
+
+    def transform_issuer_metadata(self, metadata: dict) -> None:
+        """Convert mso_mdoc algorithm names to COSE integer identifiers.
+
+        Per OID4VCI spec Appendix E and ISO 18013-5, ``credential_signing_alg_
+        values_supported`` for mso_mdoc must contain COSE algorithm integer
+        identifiers (e.g. -7 for ES256), NOT string names. This method converts
+        any string entries in-place.
+        """
+        algs = metadata.get("credential_signing_alg_values_supported")
+        if algs:
+            metadata["credential_signing_alg_values_supported"] = [
+                self._COSE_ALG.get(a, a) if isinstance(a, str) else a for a in algs
+            ]

--- a/oid4vc/oid4vc/__init__.py
+++ b/oid4vc/oid4vc/__init__.py
@@ -9,6 +9,7 @@ from acapy_agent.core.profile import Profile
 from acapy_agent.core.util import SHUTDOWN_EVENT_PATTERN, STARTUP_EVENT_PATTERN
 from acapy_agent.resolver.did_resolver import DIDResolver
 from acapy_agent.wallet.did_method import DIDMethods
+from acapy_agent.wallet.key_type import P256, KeyTypes
 
 from oid4vc.cred_processor import CredProcessors
 
@@ -41,6 +42,10 @@ async def setup(context: InjectionContext):
     methods = context.inject(DIDMethods)
     methods.register(DID_JWK)
 
+    # Register P256 key type (used by mDOC and other EC-based formats)
+    key_types = context.inject(KeyTypes)
+    key_types.register(P256)
+
     # Include jwt_vc_json by default
     jwt_vc_json = JwtVcJsonCredProcessor()
     processors = CredProcessors()
@@ -48,8 +53,14 @@ async def setup(context: InjectionContext):
     processors.register_issuer("jwt_vc", jwt_vc_json)
     processors.register_cred_verifier("jwt_vc_json", jwt_vc_json)
     processors.register_cred_verifier("jwt_vc", jwt_vc_json)
+    # jwt_vp_json/jwt_vp are VP envelope formats; register as both verifier types
+    # so format-specific processors can verify credentials inside VP envelopes
+    processors.register_cred_verifier("jwt_vp_json", jwt_vc_json)
+    processors.register_cred_verifier("jwt_vp", jwt_vc_json)
     processors.register_pres_verifier("jwt_vp_json", jwt_vc_json)
     processors.register_pres_verifier("jwt_vp", jwt_vc_json)
+    # Note: format-specific plugins (mso_mdoc, sd_jwt_vc) register themselves
+    # in their own setup() functions when loaded as plugins
 
     context.injector.bind_instance(CredProcessors, processors)
 

--- a/oid4vc/oid4vc/cred_processor.py
+++ b/oid4vc/oid4vc/cred_processor.py
@@ -77,11 +77,11 @@ class IssuerError(CredProcessorError):
     """Raised on issuer errors."""
 
 
-class CredVerifeirError(CredProcessorError):
+class CredVerifierError(CredProcessorError):
     """Raised on credential verifier errors."""
 
 
-class PresVerifeirError(CredProcessorError):
+class PresVerifierError(CredProcessorError):
     """Raised on presentation verifier errors."""
 
 

--- a/oid4vc/oid4vc/dcql.py
+++ b/oid4vc/oid4vc/dcql.py
@@ -189,34 +189,14 @@ class DCQLQueryEvaluator:
                 None,
             )
 
-        # Doctype validation for mDOC credentials
-        if cred.meta:
-            expected_doctypes = []
-            if cred.meta.doctype_value:
-                expected_doctypes = [cred.meta.doctype_value]
-            elif cred.meta.doctype_values:
-                expected_doctypes = cred.meta.doctype_values
-
-            if expected_doctypes:
-                presented_doctype = vc_result.payload.get("docType")
-                if presented_doctype is None:
-                    return (
-                        False,
-                        f"Credential for {cred.credential_query_id} is missing doctype",
-                        None,
-                    )
-                if presented_doctype not in expected_doctypes:
-                    return (
-                        False,
-                        f"Presented doctype '{presented_doctype}' does not "
-                        f"match requested doctype(s): {expected_doctypes}",
-                        None,
-                    )
-
-        if cred.meta and cred.meta.vct_values:
-            presented_vct = vc_result.payload.get("vct")
-            if presented_vct not in cred.meta.vct_values:
-                return (False, "Presented vct does not match requested vct(s).", None)
+        # Credential type validation (doctype for mDOC, vct for SD-JWT, etc.)
+        # Uses processor extension point if available, otherwise falls back to
+        # hardcoded checks for backward compatibility.
+        type_validation_result = self._validate_credential_type(
+            cred_verifier, cred, vc_result.payload
+        )
+        if not type_validation_result[0]:
+            return (type_validation_result[0], type_validation_result[1], None)
 
         # Handle ClaimSets - if defined, at least one claim set must be satisfied
         claims_result = await self._verify_claims(cred, vc_result.payload)
@@ -332,6 +312,61 @@ class DCQLQueryEvaluator:
                 return (
                     False,
                     "Credential presented did not match the values required by the query",
+                )
+
+        return (True, None)
+
+    def _validate_credential_type(
+        self,
+        cred_verifier,
+        cred: CredentialQuery,
+        payload: dict,
+    ) -> Tuple[bool, Optional[str]]:
+        """Validate credential type identifier (doctype, vct, etc.).
+
+        Uses processor extension point if available:
+        - validate_type_identifier(payload, expected_types) -> Tuple[bool, Optional[str]]
+
+        Falls back to built-in checks for doctype (mDOC) and vct (SD-JWT) if the
+        processor doesn't implement the extension.
+
+        Returns:
+            Tuple of (success, error_message)
+        """
+        if not cred.meta:
+            return (True, None)
+
+        # Collect expected type identifiers from meta
+        expected_types = []
+        type_field = None
+
+        if cred.meta.doctype_value:
+            expected_types = [cred.meta.doctype_value]
+            type_field = "docType"
+        elif cred.meta.doctype_values:
+            expected_types = cred.meta.doctype_values
+            type_field = "docType"
+        elif cred.meta.vct_values:
+            expected_types = cred.meta.vct_values
+            type_field = "vct"
+
+        if not expected_types:
+            return (True, None)
+
+        # Use processor extension point if available
+        if hasattr(cred_verifier, "validate_type_identifier"):
+            return cred_verifier.validate_type_identifier(payload, expected_types)
+
+        # Fallback: built-in validation for known type fields
+        if type_field:
+            presented_type = payload.get(type_field)
+            if presented_type is None:
+                return (False, f"Credential is missing {type_field}")
+            if presented_type not in expected_types:
+                return (
+                    False,
+                    f"Presented {type_field} '{presented_type}' does not "
+                    f"match requested type(s): {expected_types}",
                 )
 
         return (True, None)

--- a/oid4vc/oid4vc/models/supported_cred.py
+++ b/oid4vc/oid4vc/models/supported_cred.py
@@ -105,12 +105,23 @@ class SupportedCredential(BaseRecord):
             )
         }
 
-    def to_issuer_metadata(self) -> dict:
+    def to_issuer_metadata(self, issuer=None) -> dict:
         """Return a representation of this record as issuer metadata.
 
         To arrive at the structure defined by the specification, it must be
         derived from this record (the record itself is not exactly aligned with
         the spec).
+
+        Args:
+            issuer: Optional credential issuer processor. If the processor
+                implements ``format_data_is_top_level()`` (returns True) the
+                format_data fields are emitted at the top level of the
+                credential configuration object rather than being wrapped in
+                ``credential_definition``.  If the processor additionally
+                implements ``transform_issuer_metadata(metadata)`` that method
+                is called with the partially-built metadata dict for any
+                format-specific post-processing (e.g. converting algorithm
+                names, reshaping claims arrays).
         """
         issuer_metadata = {
             prop: value
@@ -126,18 +137,52 @@ class SupportedCredential(BaseRecord):
         alg_supported = issuer_metadata.pop("cryptographic_suites_supported", None)
         if alg_supported:
             issuer_metadata["credential_signing_alg_values_supported"] = alg_supported
-        issuer_metadata["id"] = self.identifier
-        issuer_metadata["credential_definition"] = (
-            self.format_data if self.format_data else {}
+
+        # NOTE: Per OID4VCI spec §11.2.3, the credential configuration identifier
+        # is ONLY the map key in credential_configurations_supported, never a
+        # field inside the object.  Do NOT add "id" here.
+
+        format_data = self.format_data or {}
+
+        # Extension point: processors can opt in to top-level format_data layout
+        # (used by SD-JWT and mDOC formats per OID4VCI spec) by implementing
+        # format_data_is_top_level().  Falls back to the legacy
+        # credential_definition wrapping used by jwt_vc_json / ldp_vc.
+        use_top_level = hasattr(issuer, "format_data_is_top_level") and bool(
+            issuer.format_data_is_top_level()
         )
-        context = issuer_metadata["credential_definition"].pop("context", None)
-        if context:
-            issuer_metadata["credential_definition"]["@context"] = context
-        issuer_metadata["credential_definition"] = {
-            k: v
-            for k, v in issuer_metadata["credential_definition"].items()
-            if v is not None
-        }
+
+        if use_top_level:
+            # SD-JWT and mDOC formats: format_data fields (e.g. vct, claims,
+            # doctype) belong at the top level of the credential configuration.
+            for key, value in format_data.items():
+                if value is None:
+                    continue
+                if key == "cryptographic_suites_supported":
+                    # Deprecated field — promote to OID4VCI 1.0 name if not
+                    # already set by the model-level attribute above.
+                    if "credential_signing_alg_values_supported" not in issuer_metadata:
+                        issuer_metadata["credential_signing_alg_values_supported"] = value
+                    continue
+                issuer_metadata[key] = value
+        else:
+            # JWT VC JSON, JSON-LD, and other formats: format_data is wrapped in
+            # credential_definition per OID4VCI spec.
+            credential_definition = dict(format_data)
+            context = credential_definition.pop("context", None)
+            if context:
+                credential_definition["@context"] = context
+            issuer_metadata["credential_definition"] = {
+                k: v for k, v in credential_definition.items() if v is not None
+            }
+
+        # Extension point: processors can implement transform_issuer_metadata()
+        # to perform format-specific post-processing (e.g. COSE algorithm name
+        # → integer conversion for mDOC, claims dict → array for SD-JWT).
+        # The method receives the metadata dict and may mutate it in place.
+        if hasattr(issuer, "transform_issuer_metadata"):
+            issuer.transform_issuer_metadata(issuer_metadata)
+
         return issuer_metadata
 
 

--- a/oid4vc/oid4vc/pex.py
+++ b/oid4vc/oid4vc/pex.py
@@ -59,7 +59,11 @@ class InputDescriptorMappingSchema(BaseModelSchema):
         model_class = InputDescriptorMapping
         unknown = EXCLUDE
 
-    id = fields.Str(required=True, metadata={"description": "ID"})
+    # PEX 2.0 §5.1.1 technically requires `id` in every descriptor_map entry.
+    # However, some wallets omit it in practice (e.g. waltid).  Making the
+    # field optional here is a deliberate interoperability relaxation; the
+    # evaluator compensates with positional matching as a fallback.
+    id = fields.Str(required=False, load_default=None, metadata={"description": "ID"})
     fmt = fields.Str(
         required=True,
         dump_default="ldp_vc",
@@ -213,9 +217,10 @@ class DescriptorEvaluator:
         else:
             raise TypeError("descriptor must be dict or InputDescriptor")
 
+        constraint_fields = descriptor.constraint._fields if descriptor.constraint else []
         field_constraints = [
             ConstraintFieldEvaluator.compile(constraint)
-            for constraint in descriptor.constraint._fields
+            for constraint in constraint_fields
         ]
         return cls(descriptor.id, field_constraints)
 
@@ -284,9 +289,18 @@ class PresentationExchangeEvaluator:
 
         descriptor_id_to_claims = {}
         descriptor_id_to_fields = {}
-        for item in submission.descriptor_maps or []:
+        descriptors_list = list(self._id_to_descriptor.values())
+        for idx, item in enumerate(submission.descriptor_maps or []):
             # TODO Check JWT VP generally, if format is jwt_vp
-            evaluator = self._id_to_descriptor.get(item.id)
+            evaluator = self._id_to_descriptor.get(item.id) if item.id else None
+            if not evaluator and item.id is None and idx < len(descriptors_list):
+                # Deliberate interoperability relaxation: PEX 2.0 §5.1.1
+                # requires descriptor_map entries to carry an `id` matching an
+                # input descriptor id, but some wallets omit the field entirely.
+                # When id is absent, fall back to positional matching — the Nth
+                # submission entry is evaluated against the Nth input descriptor.
+                # Named lookup (above) always takes priority when id IS present.
+                evaluator = descriptors_list[idx]
             if not evaluator:
                 return PexVerifyResult(
                     details=f"Could not find input descriptor corresponding to {item.id}"

--- a/oid4vc/oid4vc/public_routes/metadata.py
+++ b/oid4vc/oid4vc/public_routes/metadata.py
@@ -78,6 +78,7 @@ async def credential_issuer_metadata(request: web.Request):
             ]
         metadata["credential_endpoint"] = f"{public_url}{subpath}/credential"
         metadata["notification_endpoint"] = f"{public_url}{subpath}/notification"
+        metadata["nonce_endpoint"] = f"{public_url}{subpath}/nonce"
         processors = context.inject(CredProcessors)
         cred_configs = {}
         for supported in credentials_supported:

--- a/oid4vc/oid4vc/public_routes/metadata.py
+++ b/oid4vc/oid4vc/public_routes/metadata.py
@@ -10,6 +10,7 @@ from aiohttp_apispec import docs, response_schema
 from marshmallow import fields
 
 from ..config import Config
+from ..cred_processor import CredProcessors
 from ..models.supported_cred import SupportedCredential
 from ..utils import get_tenant_subpath
 
@@ -77,10 +78,17 @@ async def credential_issuer_metadata(request: web.Request):
             ]
         metadata["credential_endpoint"] = f"{public_url}{subpath}/credential"
         metadata["notification_endpoint"] = f"{public_url}{subpath}/notification"
-        metadata["credential_configurations_supported"] = {
-            supported.identifier: supported.to_issuer_metadata()
-            for supported in credentials_supported
-        }
+        processors = context.inject(CredProcessors)
+        cred_configs = {}
+        for supported in credentials_supported:
+            try:
+                issuer = processors.issuer_for_format(supported.format)
+            except Exception:
+                issuer = None
+            cred_configs[supported.identifier] = supported.to_issuer_metadata(
+                issuer=issuer
+            )
+        metadata["credential_configurations_supported"] = cred_configs
 
     LOGGER.debug("METADATA: %s", metadata)
 

--- a/oid4vc/oid4vc/tests/test_additional_coverage.py
+++ b/oid4vc/oid4vc/tests/test_additional_coverage.py
@@ -866,6 +866,71 @@ class TestSupportedCredentials:
         assert "x5c" in supported_cred.cryptographic_binding_methods_supported
         assert "PS256" in supported_cred.cryptographic_suites_supported
 
+    def test_to_issuer_metadata_default_wraps_in_credential_definition(self):
+        """Without a processor, format_data is wrapped in credential_definition."""
+        supported_cred = SupportedCredential(
+            identifier="test_cred",
+            format="jwt_vc_json",
+            format_data={"credentialSubject": {"name": "alice"}},
+        )
+        metadata = supported_cred.to_issuer_metadata()
+        assert "credential_definition" in metadata
+        assert metadata["credential_definition"] == {
+            "credentialSubject": {"name": "alice"}
+        }
+        assert "credentialSubject" not in metadata
+
+    def test_to_issuer_metadata_top_level_when_processor_opts_in(self):
+        """Processors implementing format_data_is_top_level() get top-level layout."""
+
+        class FakeTopLevelIssuer:
+            def format_data_is_top_level(self):
+                return True
+
+        supported_cred = SupportedCredential(
+            identifier="test_cred",
+            format="vc+sd-jwt",
+            format_data={"vct": "https://example.com/PID", "claims": {"name": {}}},
+        )
+        metadata = supported_cred.to_issuer_metadata(issuer=FakeTopLevelIssuer())
+        assert "credential_definition" not in metadata
+        assert metadata["vct"] == "https://example.com/PID"
+        assert metadata["claims"] == {"name": {}}
+
+    def test_to_issuer_metadata_transform_hook_is_called(self):
+        """Processors implementing transform_issuer_metadata() can post-process."""
+        called_with = []
+
+        class FakeTransformIssuer:
+            def format_data_is_top_level(self):
+                return True
+
+            def transform_issuer_metadata(self, metadata):
+                called_with.append(dict(metadata))
+                metadata["injected"] = True
+
+        supported_cred = SupportedCredential(
+            identifier="test_cred",
+            format="dc+sd-jwt",
+            format_data={"vct": "https://example.com/Test"},
+        )
+        metadata = supported_cred.to_issuer_metadata(issuer=FakeTransformIssuer())
+        assert called_with, "transform_issuer_metadata should have been called"
+        assert metadata.get("injected") is True
+
+    def test_to_issuer_metadata_no_processor_no_extension(self):
+        """Existing behavior preserved when issuer=None (backward compat)."""
+        supported_cred = SupportedCredential(
+            identifier="compat_cred",
+            format="ldp_vc",
+            format_data={"context": ["https://www.w3.org/2018/credentials/v1"]},
+        )
+        metadata = supported_cred.to_issuer_metadata()
+        assert "credential_definition" in metadata
+        assert metadata["credential_definition"]["@context"] == [
+            "https://www.w3.org/2018/credentials/v1"
+        ]
+
 
 class TestAdditionalEdgeCases:
     """Test edge cases and error conditions."""

--- a/oid4vc/sd_jwt_vc/cred_processor.py
+++ b/oid4vc/sd_jwt_vc/cred_processor.py
@@ -216,6 +216,33 @@ class SdJwtCredIssueProcessor(Issuer, CredVerifier, PresVerifier):
         if bad_pointer:
             raise ValueError(f"Invalid JSON pointer(s): {bad_pointer}")
 
+    def format_data_is_top_level(self) -> bool:
+        """SD-JWT format_data fields belong at the top level of credential config."""
+        return True
+
+    def transform_issuer_metadata(self, metadata: dict) -> None:
+        """Convert SD-JWT claims dict to array format required by OID4VCI spec.
+
+        The OIDF conformance suite requires ``claims`` to be an array of
+        per-claim objects (not a dict) per OID4VCI 1.0 spec §E.2.2.
+        Stored format_data uses the legacy dict form
+        ``{claim_name: {display: [...], mandatory: bool}}``; this method
+        converts it in-place to the spec-compliant array form:
+        ``[{path: [claim_name], display: [...], mandatory: bool}]``.
+        """
+        claims = metadata.get("claims")
+        if isinstance(claims, dict):
+            claims_arr = []
+            for claim_name, claim_meta in claims.items():
+                entry: dict = {"path": [claim_name]}
+                if isinstance(claim_meta, dict):
+                    if "display" in claim_meta:
+                        entry["display"] = claim_meta["display"]
+                    if "mandatory" in claim_meta:
+                        entry["mandatory"] = claim_meta["mandatory"]
+                claims_arr.append(entry)
+            metadata["claims"] = claims_arr
+
     async def verify_presentation(
         self,
         profile: Profile,


### PR DESCRIPTION
Adds _validate_credential_type() method that allows credential processors to implement validate_type_identifier(payload, expected) for custom type validation.

Falls back to built-in validation for docType (mDOC) and vct (SD-JWT) if the processor doesn't implement the extension.

This enables format-specific PRs to be independent - each format can add its validation logic without modifying shared DCQL code.

No behavior change for existing formats - all existing DCQL tests pass.