### PR TITLE
feat(oid4vc): add OID4VP Final spec support with DCQL and x5c key binding

### DIFF
--- a/oid4vc/oid4vc/migrate.py
+++ b/oid4vc/oid4vc/migrate.py
@@ -17,6 +17,7 @@ crash mid-run leaves the database in a known, named state.
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
 from importlib.metadata import version as _pkg_version
@@ -36,9 +37,12 @@ LOGGER = logging.getLogger(__name__)
 _VERSION_RECORD_TYPE = "oid4vc:version"
 _VERSION_RECORD_ID = "schema-version"
 
-# Baseline: data created before version tracking was introduced.
-# Any DB without a version record is implicitly at this version.
+# Baseline sentinel: data created before version tracking was introduced.
+# Any DB that has no version record is implicitly at this version.
 _UNVERSIONED = (0, 0, 0)
+
+_DCQL_OLD_RECORD_TYPE = "oid4vp"
+_DCQL_NEW_RECORD_TYPE = "oid4vp-dcql"
 
 
 # ---------------------------------------------------------------------------
@@ -50,6 +54,7 @@ _VersionTuple = tuple[int, ...]
 
 def _parse(version_str: str) -> _VersionTuple:
     """Parse a PEP-440 version string into a comparable tuple of ints."""
+    # Strip pre/post/dev suffixes by taking only the numeric release segment.
     numeric = version_str.split("+")[0].split("a")[0].split("b")[0].split("rc")[0]
     return tuple(int(x) for x in numeric.split("."))
 
@@ -88,6 +93,80 @@ async def _set_db_version(storage: BaseStorage, ver: _VersionTuple) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Transformations — 0.1.0
+# ---------------------------------------------------------------------------
+
+async def _to_0_1_0_dcql_record_type(profile: Profile) -> int:
+    """Forward: DCQLQuery RECORD_TYPE "oid4vp" → "oid4vp-dcql".
+
+    All three OID4VP model types shared ``RECORD_TYPE = "oid4vp"`` before
+    this change.  DCQLQuery records are identified by a top-level
+    ``"credentials"`` key that Presentation and Request bodies never have.
+    """
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        records = await storage.find_all_records(_DCQL_OLD_RECORD_TYPE)
+
+        migrated = 0
+        for record in records:
+            try:
+                body = json.loads(record.value)
+            except (json.JSONDecodeError, TypeError):
+                LOGGER.warning("Skipping oid4vp record %s: not valid JSON.", record.id)
+                continue
+
+            if "credentials" not in body:
+                continue  # Presentation / Request — leave untouched
+
+            await storage.delete_record(record)
+            await storage.add_record(
+                StorageRecord(
+                    type=_DCQL_NEW_RECORD_TYPE,
+                    value=record.value,
+                    tags=record.tags,
+                    id=record.id,
+                )
+            )
+            migrated += 1
+            LOGGER.info(
+                "DCQLQuery %s: type %r → %r", record.id,
+                _DCQL_OLD_RECORD_TYPE, _DCQL_NEW_RECORD_TYPE,
+            )
+
+        return migrated
+
+
+async def _from_0_1_0_dcql_record_type(profile: Profile) -> int:
+    """Backward: DCQLQuery RECORD_TYPE "oid4vp-dcql" → "oid4vp".
+
+    Reverses ``_to_0_1_0_dcql_record_type`` so an older version of the code
+    that expects all OID4VP records under ``"oid4vp"`` works correctly.
+    """
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        records = await storage.find_all_records(_DCQL_NEW_RECORD_TYPE)
+
+        migrated = 0
+        for record in records:
+            await storage.delete_record(record)
+            await storage.add_record(
+                StorageRecord(
+                    type=_DCQL_OLD_RECORD_TYPE,
+                    value=record.value,
+                    tags=record.tags,
+                    id=record.id,
+                )
+            )
+            migrated += 1
+            LOGGER.info(
+                "DCQLQuery %s: type %r → %r", record.id,
+                _DCQL_NEW_RECORD_TYPE, _DCQL_OLD_RECORD_TYPE,
+            )
+
+        return migrated
+
+
+# ---------------------------------------------------------------------------
 # Migration registry
 # ---------------------------------------------------------------------------
 
@@ -109,13 +188,22 @@ class _Step:
 
 
 # Keep sorted ascending by version.
-_STEPS: list[_Step] = []
+_STEPS: list[_Step] = [
+    _Step(
+        version=(0, 1, 0),
+        forward=[
+            _to_0_1_0_dcql_record_type,
+        ],
+        backward=[
+            _from_0_1_0_dcql_record_type,
+        ],
+    ),
+]
 
 
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
-
 
 async def run_migrations(profile: Profile) -> None:
     """Transform the database schema to match the installed package version.
@@ -166,11 +254,10 @@ async def run_migrations(profile: Profile) -> None:
             for fn in step.backward:
                 count = await fn(profile)
                 LOGGER.info("  %s: %d record(s) transformed.", fn.__name__, count)
+            # After reversing this step the DB is at the *previous* version.
             idx = _STEPS.index(step)
             prev = _STEPS[idx - 1].version if idx > 0 else _UNVERSIONED
             async with profile.session() as session:
                 storage = session.inject(BaseStorage)
                 await _set_db_version(storage, prev)
-            LOGGER.info(
-                "Step %s reversed; DB now at %s.", _fmt(step.version), _fmt(prev)
-            )
+            LOGGER.info("Step %s reversed; DB now at %s.", _fmt(step.version), _fmt(prev))

--- a/oid4vc/oid4vc/models/dcql_query.py
+++ b/oid4vc/oid4vc/models/dcql_query.py
@@ -333,7 +333,7 @@ class DCQLQuery(BaseRecord):
 
     RECORD_ID_NAME = "dcql_query_id"
     RECORD_TOPIC = "oid4vp"
-    RECORD_TYPE = "oid4vp"
+    RECORD_TYPE = "oid4vp-dcql"
 
     def __init__(
         self,

--- a/oid4vc/oid4vc/models/presentation.py
+++ b/oid4vc/oid4vc/models/presentation.py
@@ -43,6 +43,7 @@ class OID4VPPresentation(BaseRecord):
         verified: Optional[bool] = None,
         request_id: str,
         nonce: Optional[str] = None,
+        client_id: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Initialize an OID4VP Presentation instance."""
@@ -56,6 +57,7 @@ class OID4VPPresentation(BaseRecord):
         self.request_id = request_id
         self.dcql_query_id = dcql_query_id
         self.nonce = nonce  # in request
+        self.client_id = client_id
 
     @property
     def presentation_id(self) -> str:
@@ -72,6 +74,7 @@ class OID4VPPresentation(BaseRecord):
                 "matched_credentials",
                 "verified",
                 "nonce",
+                "client_id",
             )
         }
 
@@ -119,6 +122,13 @@ class OID4VPPresentationSchema(BaseRecordSchema):
         required=True,
         metadata={
             "description": "Identifier used to identify presentation request",
+        },
+    )
+
+    client_id = fields.Str(
+        required=False,
+        metadata={
+            "description": "DID used as client_id in the OID4VP request",
         },
     )
 

--- a/oid4vc/oid4vc/models/request.py
+++ b/oid4vc/oid4vc/models/request.py
@@ -45,7 +45,12 @@ class OID4VPRequest(BaseRecord):
     @property
     def record_value(self) -> dict:
         """Return dict representation of the exchange record for storage."""
-        return {prop: getattr(self, prop) for prop in ("vp_formats",)}
+        result: dict = {"vp_formats": self.vp_formats}
+        if self.pres_def_id is not None:
+            result["pres_def_id"] = self.pres_def_id
+        if self.dcql_query_id is not None:
+            result["dcql_query_id"] = self.dcql_query_id
+        return result
 
 
 class OID4VPRequestSchema(BaseRecordSchema):

--- a/oid4vc/oid4vc/pex.py
+++ b/oid4vc/oid4vc/pex.py
@@ -60,9 +60,10 @@ class InputDescriptorMappingSchema(BaseModelSchema):
         unknown = EXCLUDE
 
     # PEX 2.0 §5.1.1 technically requires `id` in every descriptor_map entry.
-    # However, some wallets omit it in practice (e.g. waltid).  Making the
-    # field optional here is a deliberate interoperability relaxation; the
-    # evaluator compensates with positional matching as a fallback.
+    # However, some wallets (e.g. waltid) omit it in practice.  Making the
+    # field optional here is a deliberate interoperability relaxation for
+    # non-conformant wallets; the evaluator compensates with positional
+    # matching as a fallback (see PresentationExchangeEvaluator.verify).
     id = fields.Str(required=False, load_default=None, metadata={"description": "ID"})
     fmt = fields.Str(
         required=True,
@@ -217,10 +218,9 @@ class DescriptorEvaluator:
         else:
             raise TypeError("descriptor must be dict or InputDescriptor")
 
-        constraint_fields = descriptor.constraint._fields if descriptor.constraint else []
+        fields = descriptor.constraint._fields if descriptor.constraint else []
         field_constraints = [
-            ConstraintFieldEvaluator.compile(constraint)
-            for constraint in constraint_fields
+            ConstraintFieldEvaluator.compile(constraint) for constraint in fields
         ]
         return cls(descriptor.id, field_constraints)
 
@@ -295,11 +295,12 @@ class PresentationExchangeEvaluator:
             evaluator = self._id_to_descriptor.get(item.id) if item.id else None
             if not evaluator and item.id is None and idx < len(descriptors_list):
                 # Deliberate interoperability relaxation: PEX 2.0 §5.1.1
-                # requires descriptor_map entries to carry an `id` matching an
-                # input descriptor id, but some wallets omit the field entirely.
-                # When id is absent, fall back to positional matching — the Nth
-                # submission entry is evaluated against the Nth input descriptor.
-                # Named lookup (above) always takes priority when id IS present.
+                # requires descriptor_map entries to carry an `id` that
+                # matches an input descriptor id, but some wallets (e.g.
+                # waltid) omit the field entirely.  When id is absent we
+                # fall back to positional matching — the Nth submission entry
+                # is evaluated against the Nth input descriptor.  Named
+                # lookup (above) always takes priority when id IS present.
                 evaluator = descriptors_list[idx]
             if not evaluator:
                 return PexVerifyResult(

--- a/oid4vc/oid4vc/public_routes/verification.py
+++ b/oid4vc/oid4vc/public_routes/verification.py
@@ -131,6 +131,36 @@ async def retrieve_or_create_did_jwk(session: ProfileSession):
     return await _create_default_did(session)
 
 
+# ---------------------------------------------------------------------------
+# X.509 identity – stores a certificate chain + signing key for x509_san_dns
+# client_id_scheme in OID4VP request objects (JAR, RFC 9101).
+# ---------------------------------------------------------------------------
+
+X509_IDENTITY_RECORD_TYPE = "OID4VP.x509_identity"
+X509_IDENTITY_RECORD_ID = "OID4VP.x509_identity"
+
+
+async def _get_x509_identity(session: ProfileSession) -> Optional[Dict[str, Any]]:
+    """Return stored X.509 identity dict, or None if not configured.
+
+    The dict has the shape::
+
+        {
+            "cert_chain": ["<base64DER_leaf>", ...],  # leaf-first
+            "verification_method": "did:jwk:...#0",
+            "client_id": "acapy-verifier.example.com",
+        }
+    """
+    storage = session.inject(BaseStorage)
+    try:
+        record = await storage.get_record(
+            X509_IDENTITY_RECORD_TYPE, X509_IDENTITY_RECORD_ID
+        )
+        return json.loads(record.value)
+    except StorageNotFoundError:
+        return None
+
+
 @docs(tags=["oid4vp"], summary="Retrive OID4VP authorization request token")
 @match_info_schema(OID4VPRequestIDMatchSchema())
 async def get_request(request: web.Request):
@@ -148,15 +178,26 @@ async def get_request(request: web.Request):
             pres = await OID4VPPresentation.retrieve_by_request_id(
                 session=session, request_id=request_id
             )
-            pres.state = OID4VPPresentation.REQUEST_RETRIEVED
-            pres.nonce = token_urlsafe(NONCE_BYTES)
-            await pres.save(session=session, reason="Retrieved presentation request")
 
             if record.pres_def_id:
                 pres_def = await OID4VPPresDef.retrieve_by_id(session, record.pres_def_id)
             elif record.dcql_query_id:
                 dcql_query = await DCQLQuery.retrieve_by_id(session, record.dcql_query_id)
             jwk = await retrieve_or_create_did_jwk(session)
+            x509_id = await _get_x509_identity(session)
+
+            pres.state = OID4VPPresentation.REQUEST_RETRIEVED
+            pres.nonce = token_urlsafe(NONCE_BYTES)
+            # Use x509 client_id when configured (x509_san_dns scheme).
+            # OID4VP Final (ID3+) encodes the scheme as a URI prefix in client_id:
+            #   x509_san_dns:{dns_name}  (e.g. "x509_san_dns:acapy-tls-proxy.local")
+            # This replaces the old separate client_id_scheme parameter.
+            if x509_id:
+                effective_client_id = f"x509_san_dns:{x509_id['client_id']}"
+            else:
+                effective_client_id = jwk.did
+            pres.client_id = effective_client_id
+            await pres.save(session=session, reason="Retrieved presentation request")
 
     except StorageNotFoundError as err:
         raise web.HTTPNotFound(reason=err.roll_up) from err
@@ -171,16 +212,32 @@ async def get_request(request: web.Request):
         else None
     )
     subpath = f"/tenant/{wallet_id}" if wallet_id else ""
+    # Use OID4VP_ENDPOINT when available (may differ from the OID4VCI endpoint;
+    # e.g. behind a dedicated TLS-terminating proxy for conformance tests).
+    oid4vp_base = config.oid4vp_endpoint or config.endpoint
     payload = {
-        "iss": jwk.did,
-        "sub": jwk.did,
+        "iss": effective_client_id,
+        # NOTE: Do NOT include 'sub' equal to client_id in OID4VP JAR.
+        # RFC 7519: sub identifies the principal that is the subject of the JWT,
+        # but the JAR does not have a meaningful 'subject'.  Including sub=client_id
+        # triggers a security warning (potential for use as client auth assertion).
         "iat": now,
         "nbf": now,
         "exp": now + 120,
         "jti": str(uuid.uuid4()),
-        "client_id": config.endpoint,
+        # client_id: when using x509_san_dns the value is a DNS name that
+        # matches the SAN of the leaf certificate.  For did:jwk the value is
+        # the DID itself (scheme inferred from prefix, no explicit
+        # client_id_scheme — see note below).
+        # NOTE: Do NOT include "client_id_scheme" in OID4VP Final (ID3+): the
+        # scheme is encoded as a URI prefix in client_id itself.
+        # For x509_san_dns: client_id = "x509_san_dns:{dns_name}".
+        # For did:jwk: client_id = the DID itself ("did:jwk:...").
+        # The x5c cert chain in the JWT header establishes the x509 binding.
+        # Do NOT add a separate client_id_scheme parameter — it causes failures.
+        "client_id": effective_client_id,
         "response_uri": (
-            f"{config.endpoint}{subpath}/oid4vp/response/{pres.presentation_id}"
+            f"{oid4vp_base}{subpath}/oid4vp/response/{pres.presentation_id}"
         ),
         "state": pres.presentation_id,
         "nonce": pres.nonce,
@@ -190,26 +247,45 @@ async def get_request(request: web.Request):
         "scopes_supported": ["openid", "vp_token"],
         "subject_types_supported": ["pairwise"],
         "subject_syntax_types_supported": ["urn:ietf:params:oauth:jwk-thumbprint"],
+        # OID4VP Final: vp_formats MUST be inside client_metadata when using
+        # x509_san_dns (verifier has no metadata document URL).  Keep top-level
+        # vp_formats as well for broad wallet compatibility.
+        "client_metadata": {
+            "vp_formats": record.vp_formats,
+            "authorization_signed_response_alg": "ES256",
+        },
         "vp_formats": record.vp_formats,
         "response_type": "vp_token",
         "response_mode": "direct_post",
-        "scope": "vp_token",
+        # NOTE: Do NOT include "scope" here. The @openid4vc/openid4vp library
+        # validates that EXACTLY ONE of {scope, presentation_definition,
+        # presentation_definition_uri, dcql_query} is present. Including scope
+        # alongside presentation_definition or dcql_query causes a validation error.
     }
     if pres_def is not None:
         payload["presentation_definition"] = pres_def.pres_def
     if dcql_query is not None:
         payload["dcql_query"] = dcql_query.record_value
 
-    headers = {
-        "kid": f"{jwk.did}#0",
-        "typ": "oauth-authz-req+jwt",
-    }
+    if x509_id:
+        headers = {
+            "x5c": x509_id["cert_chain"],
+            "typ": "oauth-authz-req+jwt",
+            "alg": "ES256",
+        }
+        signing_vm = x509_id["verification_method"]
+    else:
+        headers = {
+            "kid": f"{jwk.did}#0",
+            "typ": "oauth-authz-req+jwt",
+        }
+        signing_vm = f"{jwk.did}#0"
 
     token = await jwt_sign(
         profile=context.profile,
         payload=payload,
         headers=headers,
-        verification_method=f"{jwk.did}#0",
+        verification_method=signing_vm,
     )
 
     LOGGER.debug("TOKEN: %s", token)
@@ -256,12 +332,10 @@ async def verify_dcql_presentation(
     LOGGER.debug("Got: %s", vp_token)
 
     async with profile.session() as session:
-        pres_def_entry = await DCQLQuery.retrieve_by_id(
+        dcql_query = await DCQLQuery.retrieve_by_id(
             session,
             dcql_query_id,
         )
-
-        dcql_query = DCQLQuery.deserialize(pres_def_entry)
 
     evaluator = DCQLQueryEvaluator.compile(dcql_query)
     result = await evaluator.verify(profile, vp_token, presentation)
@@ -298,6 +372,16 @@ async def verify_pres_def_presentation(
         presentation_record=presentation,
     )
 
+    if not vp_result.verified:
+        error_msg = (
+            vp_result.payload.get("error", "Presentation verification failed")
+            if isinstance(vp_result.payload, dict)
+            else "Presentation verification failed"
+        )
+        if isinstance(error_msg, list):
+            error_msg = "; ".join(str(e) for e in error_msg)
+        return PexVerifyResult(details=str(error_msg))
+
     async with profile.session() as session:
         pres_def_entry = await OID4VPPresDef.retrieve_by_id(
             session,
@@ -307,7 +391,23 @@ async def verify_pres_def_presentation(
         pres_def = PresentationDefinition.deserialize(pres_def_entry.pres_def)
 
     evaluator = PresentationExchangeEvaluator.compile(pres_def)
-    result = await evaluator.verify(profile, submission, vp_result.payload)
+
+    # For mso_mdoc presentations, vp_result.payload is an already-decoded claims
+    # dict.  The presentation_submission from wallets (e.g. waltid) typically
+    # references $.documents[N] which is a path into the raw DeviceResponse CBOR,
+    # not the decoded dict.  Wrap the decoded payload so that $.documents[0]
+    # correctly resolves to the pre-verified claims.
+    item = submission.descriptor_maps[0]
+    if (
+        item.path_nested
+        and item.path_nested.path
+        and ".documents[" in item.path_nested.path
+    ):
+        eval_presentation: dict = {"documents": [vp_result.payload]}
+    else:
+        eval_presentation = vp_result.payload
+
+    result = await evaluator.verify(profile, submission, eval_presentation)
     return result
 
 
@@ -321,9 +421,14 @@ async def post_response(request: web.Request):
 
     form = await request.post()
 
+    # presentation_submission is only present for PEX (pres_def) presentations;
+    # DCQL presentations omit it and send vp_token as a JSON object instead.
     raw_submission = form.get("presentation_submission")
-    assert isinstance(raw_submission, str)
-    presentation_submission = PresentationSubmission.from_json(raw_submission)
+    presentation_submission = (
+        PresentationSubmission.from_json(raw_submission)
+        if isinstance(raw_submission, str)
+        else None
+    )
 
     vp_token = form.get("vp_token")
     state = form.get("state")
@@ -335,9 +440,14 @@ async def post_response(request: web.Request):
         record = await OID4VPPresentation.retrieve_by_id(session, presentation_id)
 
     try:
-        assert isinstance(vp_token, str)
+        if not isinstance(vp_token, str):
+            raise web.HTTPBadRequest(reason="vp_token must be a string")
 
         if record.pres_def_id:
+            if presentation_submission is None:
+                raise web.HTTPBadRequest(
+                    reason="presentation_submission is required for PEX presentations"
+                )
             verify_result = await verify_pres_def_presentation(
                 profile=context.profile,
                 submission=presentation_submission,
@@ -360,6 +470,23 @@ async def post_response(request: web.Request):
         raise web.HTTPNotFound(reason=err.roll_up) from err
     except (StorageError, BaseModelError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
+    except Exception as err:
+        # Catch all other exceptions (e.g. CredProcessorError, unsupported format),
+        # save the record as invalid so the holder gets a response and callers can
+        # observe the failure rather than timing out on request-retrieved.
+        error_msg = str(err)
+        LOGGER.exception(
+            "Unexpected error processing presentation %s: %s",
+            presentation_id,
+            error_msg,
+        )
+        record.state = OID4VPPresentation.PRESENTATION_INVALID
+        record.errors = [f"Processing error: {error_msg}"]
+        record.verified = False
+        record.matched_credentials = {}
+        async with context.session() as session:
+            await record.save(session, reason="Presentation processing failed")
+        return web.json_response({})
 
     if verify_result.verified:
         record.state = OID4VPPresentation.PRESENTATION_VALID
@@ -382,4 +509,6 @@ async def post_response(request: web.Request):
         )
 
     LOGGER.debug("Presentation result: %s", record.verified)
-    return web.Response(status=200)
+    # OID4VP Final §6.2: verifier MUST return a JSON response body.
+    # If no redirect_uri is required, return an empty JSON object.
+    return web.json_response({})

--- a/oid4vc/oid4vc/routes/vp_request.py
+++ b/oid4vc/oid4vc/routes/vp_request.py
@@ -1,10 +1,14 @@
 """OID4VP request routes for admin API."""
 
+import json
+import re
+from typing import List
 from urllib.parse import quote
 
 from acapy_agent.admin.request_context import AdminRequestContext
 from acapy_agent.messaging.models.base import BaseModelError
 from acapy_agent.messaging.models.openapi import OpenAPISchema
+from acapy_agent.storage.base import BaseStorage, StorageRecord
 from acapy_agent.storage.error import StorageError, StorageNotFoundError
 from aiohttp import web
 from aiohttp_apispec import (
@@ -88,8 +92,26 @@ async def create_oid4vp_request(request: web.Request):
     body = await request.json()
 
     async with context.session() as session:
-        # Get the DID:JWK that will be used as client_id first
+        # Get the DID:JWK that will be used as fallback client_id
         jwk = await retrieve_or_create_did_jwk(session)
+
+        # Use x509 identity (x509_san_dns) when registered; otherwise did:jwk.
+        storage = session.inject(BaseStorage)
+        try:
+            x509_record = await storage.get_record(
+                X509_IDENTITY_RECORD_TYPE, X509_IDENTITY_RECORD_ID
+            )
+            x509_id = json.loads(x509_record.value)
+        except StorageNotFoundError:
+            x509_id = None
+
+        # OID4VP Final (ID3+): client_id for x509_san_dns scheme uses
+        # URI prefix format: "x509_san_dns:{dns_name}".
+        # This must match the client_id in the JAR payload.
+        if x509_id:
+            effective_client_id = f"x509_san_dns:{x509_id['client_id']}"
+        else:
+            effective_client_id = jwk.did
 
         if pres_def_id := body.get("pres_def_id"):
             req_record = OID4VPRequest(
@@ -101,7 +123,7 @@ async def create_oid4vp_request(request: web.Request):
                 pres_def_id=pres_def_id,
                 state=OID4VPPresentation.REQUEST_CREATED,
                 request_id=req_record.request_id,
-                client_id=jwk.did,
+                client_id=effective_client_id,
             )
             await pres_record.save(session=session)
 
@@ -115,7 +137,7 @@ async def create_oid4vp_request(request: web.Request):
                 dcql_query_id=dcql_query_id,
                 state=OID4VPPresentation.REQUEST_CREATED,
                 request_id=req_record.request_id,
-                client_id=jwk.did,
+                client_id=effective_client_id,
             )
             await pres_record.save(session=session)
         else:
@@ -124,15 +146,22 @@ async def create_oid4vp_request(request: web.Request):
             )
 
     config = Config.from_settings(context.settings)
-    wallet_id = (
-        context.profile.settings.get("wallet.id")
-        if context.profile.settings.get("multitenant.enabled")
-        else None
-    )
+    # wallet.id is present on sub-wallet profiles in all multitenant modes;
+    # do not gate on multitenant.enabled (absent from sub-wallet settings in
+    # single-wallet-askar mode), just read it directly.
+    wallet_id = context.profile.settings.get("wallet.id")
     subpath = f"/tenant/{wallet_id}" if wallet_id else ""
-    request_uri = quote(f"{config.endpoint}{subpath}/oid4vp/request/{req_record._id}")
-    client_id = quote(jwk.did)
-    full_uri = f"openid://?client_id={client_id}&request_uri={request_uri}"
+    # Use OID4VP_ENDPOINT when available (may differ from OID4VCI endpoint,
+    # e.g.served via a separate TLS-terminating proxy for conformance tests).
+    oid4vp_base = config.oid4vp_endpoint or config.endpoint
+    request_uri = quote(f"{oid4vp_base}{subpath}/oid4vp/request/{req_record._id}")
+    # In OID4VP Final spec, client_id_scheme was removed from authorization
+    # request query parameters (it was removed in ID3 / draft-28).  The scheme
+    # is communicated inside the signed JAR instead.  Do NOT include
+    # client_id_scheme as a query parameter.
+    full_uri = (
+        f"openid://?client_id={quote(effective_client_id)}&request_uri={request_uri}"
+    )
 
     return web.json_response(
         {
@@ -197,3 +226,140 @@ async def list_oid4vp_requests(request: web.Request):
     except (StorageError, BaseModelError, StorageNotFoundError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
     return web.json_response({"results": results})
+
+
+# ---------------------------------------------------------------------------
+# X.509 identity admin endpoints
+#
+# These endpoints manage a single "X.509 identity" record that lets ACA-Py act
+# as an OID4VP verifier with client_id_scheme=x509_san_dns.  The record stores
+# the DER certificate chain (base64, leaf-first) together with the
+# verification method referencing the matching signing key and the DNS name
+# used as client_id.
+# ---------------------------------------------------------------------------
+
+X509_IDENTITY_RECORD_TYPE = "OID4VP.x509_identity"
+X509_IDENTITY_RECORD_ID = "OID4VP.x509_identity"
+
+
+class RegisterX509IdentitySchema(OpenAPISchema):
+    """Request body for registering an X.509 identity."""
+
+    cert_chain_pem = fields.Str(
+        required=True,
+        metadata={
+            "description": (
+                "PEM-encoded certificate chain (leaf first, concatenated).  "
+                "Each certificate will be stored as a base64-encoded DER value "
+                "in the x5c array."
+            )
+        },
+    )
+    verification_method = fields.Str(
+        required=True,
+        metadata={
+            "description": (
+                'Verification method identifier (e.g. "did:jwk:...#0") that '
+                "references the key matching the leaf certificate."
+            )
+        },
+    )
+    client_id = fields.Str(
+        required=True,
+        metadata={
+            "description": (
+                "DNS name used as client_id in OID4VP requests "
+                "(must match the dNSName SAN in the leaf certificate)."
+            )
+        },
+    )
+
+
+@docs(tags=["oid4vp"], summary="Register X.509 identity for OID4VP requests")
+@request_schema(RegisterX509IdentitySchema())
+async def register_x509_identity(request: web.Request):
+    """Store an X.509 certificate chain for x509_san_dns OID4VP requests."""
+    context: AdminRequestContext = request["context"]
+    body = await request.json()
+
+    pem: str = body["cert_chain_pem"]
+    verification_method: str = body["verification_method"]
+    client_id: str = body["client_id"]
+
+    # Parse PEM → list of base64 DER strings (whitespace stripped)
+    b64_certs: List[str] = [
+        re.sub(r"\s+", "", cert)
+        for cert in re.findall(
+            r"-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----",
+            pem,
+            re.DOTALL,
+        )
+    ]
+    if not b64_certs:
+        raise web.HTTPBadRequest(reason="No certificates found in cert_chain_pem")
+
+    value = json.dumps(
+        {
+            "cert_chain": b64_certs,
+            "verification_method": verification_method,
+            "client_id": client_id,
+        }
+    )
+
+    async with context.session() as session:
+        storage = session.inject(BaseStorage)
+        # replace any existing record
+        try:
+            existing = await storage.get_record(
+                X509_IDENTITY_RECORD_TYPE, X509_IDENTITY_RECORD_ID
+            )
+            await storage.update_record(existing, value, {})
+        except StorageNotFoundError:
+            record = StorageRecord(
+                type=X509_IDENTITY_RECORD_TYPE,
+                value=value,
+                id=X509_IDENTITY_RECORD_ID,
+            )
+            await storage.add_record(record)
+
+    return web.json_response(
+        {
+            "cert_chain": b64_certs,
+            "verification_method": verification_method,
+            "client_id": client_id,
+        }
+    )
+
+
+@docs(tags=["oid4vp"], summary="Retrieve registered X.509 identity")
+async def get_x509_identity(request: web.Request):
+    """Return the stored X.509 identity record."""
+    context: AdminRequestContext = request["context"]
+
+    async with context.session() as session:
+        storage = session.inject(BaseStorage)
+        try:
+            record = await storage.get_record(
+                X509_IDENTITY_RECORD_TYPE, X509_IDENTITY_RECORD_ID
+            )
+            return web.json_response(json.loads(record.value))
+        except StorageNotFoundError:
+            raise web.HTTPNotFound(reason="No X.509 identity registered")
+
+
+@docs(tags=["oid4vp"], summary="Delete registered X.509 identity")
+async def delete_x509_identity(request: web.Request):
+    """Remove the stored X.509 identity record."""
+    context: AdminRequestContext = request["context"]
+
+    async with context.session() as session:
+        storage = session.inject(BaseStorage)
+        try:
+            record = await storage.get_record(
+                X509_IDENTITY_RECORD_TYPE, X509_IDENTITY_RECORD_ID
+            )
+            await storage.delete_record(record)
+        except StorageNotFoundError:
+            raise web.HTTPNotFound(reason="No X.509 identity registered")
+
+    return web.json_response({"deleted": True})

--- a/oid4vc/oid4vc/tests/test_migrate.py
+++ b/oid4vc/oid4vc/tests/test_migrate.py
@@ -2,19 +2,25 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import json
 
 import pytest
 from acapy_agent.storage.base import BaseStorage
+from acapy_agent.storage.record import StorageRecord
 from acapy_agent.utils.testing import create_test_profile
+from unittest.mock import patch
 
 from oid4vc.migrate import (
+    _DCQL_NEW_RECORD_TYPE,
+    _DCQL_OLD_RECORD_TYPE,
     _UNVERSIONED,
     _VERSION_RECORD_TYPE,
     _fmt,
+    _from_0_1_0_dcql_record_type,
     _get_db_version,
     _parse,
     _set_db_version,
+    _to_0_1_0_dcql_record_type,
     run_migrations,
 )
 
@@ -27,6 +33,45 @@ from oid4vc.migrate import (
 @pytest.fixture
 async def profile():
     yield await create_test_profile()
+
+
+def _dcql_record_old(dcql_id: str) -> StorageRecord:
+    """Pre-0.1.0 DCQLQuery record: stored under type "oid4vp"."""
+    body = {"credentials": [{"id": "cred1", "format": "mso_mdoc"}]}
+    return StorageRecord(
+        type=_DCQL_OLD_RECORD_TYPE,
+        value=json.dumps(body),
+        tags={"dcql_query_id": dcql_id},
+        id=dcql_id,
+    )
+
+
+def _dcql_record_new(dcql_id: str) -> StorageRecord:
+    """Post-0.1.0 DCQLQuery record: stored under type "oid4vp-dcql"."""
+    body = {"credentials": [{"id": "cred1", "format": "mso_mdoc"}]}
+    return StorageRecord(
+        type=_DCQL_NEW_RECORD_TYPE,
+        value=json.dumps(body),
+        tags={"dcql_query_id": dcql_id},
+        id=dcql_id,
+    )
+
+
+def _presentation_record(pres_id: str) -> StorageRecord:
+    """OID4VPPresentation/Request record — no 'credentials' key, stays under "oid4vp"."""
+    body = {"vp_formats": {}, "state": "request-created"}
+    return StorageRecord(
+        type=_DCQL_OLD_RECORD_TYPE,
+        value=json.dumps(body),
+        tags={"state": "request-created"},
+        id=pres_id,
+    )
+
+
+async def _store_db_version(profile, version_str: str) -> None:
+    async with profile.session() as session:
+        storage = session.inject(BaseStorage)
+        await _set_db_version(storage, _parse(version_str))
 
 
 # ---------------------------------------------------------------------------
@@ -60,8 +105,122 @@ class TestVersionHelpers:
             await _set_db_version(storage, (0, 1, 0))
             await _set_db_version(storage, (0, 2, 0))
             assert await _get_db_version(storage) == (0, 2, 0)
+            # Only one version record should exist.
             records = await storage.find_all_records(_VERSION_RECORD_TYPE)
             assert len(records) == 1
+
+
+# ---------------------------------------------------------------------------
+# Forward: to 0.1.0 — DCQLQuery type "oid4vp" → "oid4vp-dcql"
+# ---------------------------------------------------------------------------
+
+
+class TestTo010DCQLRecordType:
+    async def test_dcql_record_migrated(self, profile):
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.add_record(_dcql_record_old("q1"))
+
+        count = await _to_0_1_0_dcql_record_type(profile)
+
+        assert count == 1
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            new = await storage.find_all_records(_DCQL_NEW_RECORD_TYPE)
+            old = await storage.find_all_records(_DCQL_OLD_RECORD_TYPE)
+        assert len(new) == 1 and new[0].id == "q1"
+        assert len(old) == 0
+
+    async def test_presentation_not_touched(self, profile):
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.add_record(_presentation_record("p1"))
+
+        count = await _to_0_1_0_dcql_record_type(profile)
+        assert count == 0
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            remaining = await storage.find_all_records(_DCQL_OLD_RECORD_TYPE)
+        assert len(remaining) == 1
+
+    async def test_mixed_records(self, profile):
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.add_record(_dcql_record_old("q1"))
+            await storage.add_record(_dcql_record_old("q2"))
+            await storage.add_record(_presentation_record("p1"))
+
+        count = await _to_0_1_0_dcql_record_type(profile)
+        assert count == 2
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            new = await storage.find_all_records(_DCQL_NEW_RECORD_TYPE)
+            old = await storage.find_all_records(_DCQL_OLD_RECORD_TYPE)
+        assert {r.id for r in new} == {"q1", "q2"}
+        assert len(old) == 1 and old[0].id == "p1"
+
+    async def test_id_and_tags_preserved(self, profile):
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.add_record(_dcql_record_old("q-preserve"))
+
+        await _to_0_1_0_dcql_record_type(profile)
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            (r,) = await storage.find_all_records(_DCQL_NEW_RECORD_TYPE)
+        assert r.id == "q-preserve"
+        assert r.tags == {"dcql_query_id": "q-preserve"}
+
+    async def test_multiple_calls_idempotent(self, profile):
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.add_record(_dcql_record_old("q1"))
+
+        first = await _to_0_1_0_dcql_record_type(profile)
+        second = await _to_0_1_0_dcql_record_type(profile)
+        assert first == 1
+        assert second == 0  # already under new type, invisible to old-type scan
+
+
+# ---------------------------------------------------------------------------
+# Backward: from 0.1.0 — DCQLQuery type "oid4vp-dcql" → "oid4vp"
+# ---------------------------------------------------------------------------
+
+
+class TestFrom010DCQLRecordType:
+    async def test_new_record_rolled_back(self, profile):
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.add_record(_dcql_record_new("q1"))
+
+        count = await _from_0_1_0_dcql_record_type(profile)
+
+        assert count == 1
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            old = await storage.find_all_records(_DCQL_OLD_RECORD_TYPE)
+            new = await storage.find_all_records(_DCQL_NEW_RECORD_TYPE)
+        assert len(old) == 1 and old[0].id == "q1"
+        assert len(new) == 0
+
+    async def test_roundtrip(self, profile):
+        """Forward then backward restores original record under old type."""
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            orig = _dcql_record_old("q-rt")
+            await storage.add_record(orig)
+
+        await _to_0_1_0_dcql_record_type(profile)
+        await _from_0_1_0_dcql_record_type(profile)
+
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            old = await storage.find_all_records(_DCQL_OLD_RECORD_TYPE)
+            new = await storage.find_all_records(_DCQL_NEW_RECORD_TYPE)
+        assert len(old) == 1
+        assert old[0].id == "q-rt"
+        assert old[0].value == orig.value
+        assert len(new) == 0
 
 
 # ---------------------------------------------------------------------------
@@ -70,21 +229,87 @@ class TestVersionHelpers:
 
 
 class TestRunMigrations:
-    async def test_no_op_when_no_steps(self, profile):
-        """With _STEPS empty, run_migrations is always a no-op."""
+    async def test_no_op_when_versions_match(self, profile):
+        """If DB version equals package version nothing happens."""
+        await _store_db_version(profile, "0.1.0")
         with patch("oid4vc.migrate._pkg_version", return_value="0.1.0"):
             await run_migrations(profile)
+        # DB version unchanged
         async with profile.session() as session:
             storage = session.inject(BaseStorage)
-            # No steps → DB version never advances from _UNVERSIONED
-            assert await _get_db_version(storage) == _UNVERSIONED
+            assert await _get_db_version(storage) == (0, 1, 0)
 
-    async def test_no_op_when_versions_match(self, profile):
+    async def test_forward_migration_unversioned_to_0_1_0(self, profile):
+        """Unversioned DB (no record) → 0.1.0: forward transforms run."""
         async with profile.session() as session:
             storage = session.inject(BaseStorage)
-            await _set_db_version(storage, _parse("0.1.0"))
+            await storage.add_record(_dcql_record_old("q1"))
+
+        with patch("oid4vc.migrate._pkg_version", return_value="0.1.0"):
+            await run_migrations(profile)
+
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            (dcql,) = await storage.find_all_records(_DCQL_NEW_RECORD_TYPE)
+            db_version = await _get_db_version(storage)
+
+        assert "credentials" in json.loads(dcql.value)
+        assert db_version == (0, 1, 0)
+
+    async def test_backward_migration_0_1_0_to_unversioned(self, profile):
+        """Downgrade: 0.1.0 DB → unversioned package: backward transforms run."""
+        await _store_db_version(profile, "0.1.0")
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.add_record(_dcql_record_new("q1"))
+
+        with patch("oid4vc.migrate._pkg_version", return_value="0.0.0"):
+            await run_migrations(profile)
+
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            (dcql,) = await storage.find_all_records(_DCQL_OLD_RECORD_TYPE)
+            new_dcql = await storage.find_all_records(_DCQL_NEW_RECORD_TYPE)
+            db_version = await _get_db_version(storage)
+
+        assert "credentials" in json.loads(dcql.value)
+        assert len(new_dcql) == 0
+        assert db_version == _UNVERSIONED
+
+    async def test_db_version_updated_to_current_after_forward(self, profile):
         with patch("oid4vc.migrate._pkg_version", return_value="0.1.0"):
             await run_migrations(profile)
         async with profile.session() as session:
             storage = session.inject(BaseStorage)
             assert await _get_db_version(storage) == (0, 1, 0)
+
+    async def test_db_version_updated_to_current_after_backward(self, profile):
+        await _store_db_version(profile, "0.1.0")
+        with patch("oid4vc.migrate._pkg_version", return_value="0.0.0"):
+            await run_migrations(profile)
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            assert await _get_db_version(storage) == _UNVERSIONED
+
+    async def test_forward_then_backward_roundtrip(self, profile):
+        """Upgrade then downgrade leaves DB in original pre-migration shape."""
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            await storage.add_record(_dcql_record_old("q1"))
+            await storage.add_record(_presentation_record("p1"))
+
+        with patch("oid4vc.migrate._pkg_version", return_value="0.1.0"):
+            await run_migrations(profile)
+
+        with patch("oid4vc.migrate._pkg_version", return_value="0.0.0"):
+            await run_migrations(profile)
+
+        async with profile.session() as session:
+            storage = session.inject(BaseStorage)
+            old_oid4vp = await storage.find_all_records(_DCQL_OLD_RECORD_TYPE)
+            new_oid4vp = await storage.find_all_records(_DCQL_NEW_RECORD_TYPE)
+            db_version = await _get_db_version(storage)
+
+        assert {r.id for r in old_oid4vp} == {"q1", "p1"}
+        assert len(new_oid4vp) == 0
+        assert db_version == _UNVERSIONED


### PR DESCRIPTION
Adds OID4VP Final presentation support including DCQL and x5c-bound key verification.

## Changes
- Add OID4VP Final presentation flow with KB-JWT and x5c verification
- Add DCQL query support: `DCQLQuery` model, `dcql.py` query engine
- Update PEX to support optional `descriptor_map` id with positional fallback
- Add OID4VP presentation and request models
- Add VP request admin route (create, list, get by id)
- Add verification public route for OID4VP response handling
- Support both PEX (`presentation_definition`) and DCQL credential queries

Depends on: #20