### PR TITLE
feat(demo): mDOC OID4VC/OID4VP demo stack

### DIFF
--- a/oid4vc/demo/.env.example
+++ b/oid4vc/demo/.env.example
@@ -8,11 +8,11 @@
 # ── ACA-Py host port bindings ───────────────────────────────────────────────
 # The admin APIs and OID4VC endpoints are exposed on the host for easy curl
 # access and for the local Playwright demo script.
-# If the default ports (8021/8022) are already occupied on your machine,
+# If the default ports (8121/8122) are already occupied on your machine,
 # override them here and also set the explicit URL vars below.
 
-ACAPY_ISSUER_ADMIN_PORT=8021
-ACAPY_ISSUER_OID4VCI_PORT=8022
+ACAPY_ISSUER_ADMIN_PORT=8121
+ACAPY_ISSUER_OID4VCI_PORT=8122
 
 ACAPY_VERIFIER_ADMIN_PORT=8031
 ACAPY_VERIFIER_OID4VP_PORT=8032
@@ -23,17 +23,17 @@ ACAPY_VERIFIER_OID4VP_PORT=8032
 # Set these to match ACAPY_ISSUER_ADMIN_PORT / ACAPY_ISSUER_OID4VCI_PORT
 # whenever you override the default ports above.
 
-# ACAPY_ISSUER_ADMIN_URL=http://localhost:8021
-# ACAPY_ISSUER_OID4VCI_URL=http://localhost:8022
+# ACAPY_ISSUER_ADMIN_URL=http://localhost:8121
+# ACAPY_ISSUER_OID4VCI_URL=http://localhost:8122
 
 # ── Walt.id wallet port ─────────────────────────────────────────────────────
 # The nginx proxy combines the wallet frontend and API on this port.
-# Change if port 7101 is already in use on your machine.
-WALLET_PORT=7101
+# Change if port 7201 is already in use on your machine.
+WALLET_PORT=7201
 
 # Explicit wallet URLs for Playwright — must match WALLET_PORT above.
-# WALTID_WALLET_URL=http://localhost:7101
-# WALTID_WALLET_API_URL=http://localhost:7101
+# WALTID_WALLET_URL=http://localhost:7201
+# WALTID_WALLET_API_URL=http://localhost:7201
 
 # ── Docker platform ─────────────────────────────────────────────────────────
 # Default linux/arm64 (Apple Silicon native for ACA-Py).
@@ -63,9 +63,9 @@ WALLET_PORT=7101
 # 1. Install zrok:  https://docs.zrok.io/docs/getting-started
 # 2. Reserve permanent tunnel names once (lowercase alphanumeric, 4-32 chars):
 #
-#    zrok reserve public --unique-name "myissuerapi"  http://localhost:8022
+#    zrok reserve public --unique-name "myissuerapi"  http://localhost:8122
 #    zrok reserve public --unique-name "myverifierapi" http://localhost:8032
-#    zrok reserve public --unique-name "mydemowallet"  http://localhost:7101
+#    zrok reserve public --unique-name "mydemowallet"  http://localhost:7201
 #
 # 3. Activate all tunnels each session (in separate terminals):
 #

--- a/oid4vc/demo/README.md
+++ b/oid4vc/demo/README.md
@@ -41,7 +41,7 @@ docker compose up -d
 ./setup.sh
 
 # 5. Open the wallet in your browser
-open http://localhost:7101
+open http://localhost:7201
 ```
 
 Register a new account in the wallet and you're ready to go.
@@ -52,9 +52,9 @@ Register a new account in the wallet and you're ready to go.
 
 | Service | URL | Purpose |
 |---|---|---|
-| walt.id Web Wallet | <http://localhost:7101> | Holder wallet (browser) |
-| ACA-Py Issuer admin | <http://localhost:8021> | Issue credentials |
-| ACA-Py Issuer OID4VCI | <http://localhost:8022> | OID4VCI v1 endpoint |
+| walt.id Web Wallet | <http://localhost:7201> | Holder wallet (browser) |
+| ACA-Py Issuer admin | <http://localhost:8121> | Issue credentials |
+| ACA-Py Issuer OID4VCI | <http://localhost:8122> | OID4VCI v1 endpoint |
 | ACA-Py Verifier admin | <http://localhost:8031> | Verify presentations |
 | ACA-Py Verifier OID4VP | <http://localhost:8032> | OID4VP v1 endpoint |
 
@@ -106,9 +106,9 @@ an HTTPS endpoint — useful for testing with real mobile wallets.
 # https://docs.zrok.io/docs/getting-started
 
 # Reserve permanent tunnel names (one time)
-zrok reserve public --unique-name "myissuerapi"   http://localhost:8022
+zrok reserve public --unique-name "myissuerapi"   http://localhost:8122
 zrok reserve public --unique-name "myverifierapi" http://localhost:8032
-zrok reserve public --unique-name "mydemowallet"  http://localhost:7101
+zrok reserve public --unique-name "mydemowallet"  http://localhost:7201
 
 # Activate tunnels (each session, in separate terminals)
 zrok share reserved myissuerapi
@@ -140,8 +140,8 @@ Restart the stack: `docker compose up -d` and re-run `./setup.sh`.
 │                                                          │
 │  ┌─────────────────┐     OID4VCI v1    ┌─────────────┐  │
 │  │  ACA-Py Issuer  │ ◄──────────────── │  walt.id    │  │
-│  │  :8021 admin    │                   │  wallet-api │  │
-│  │  :8022 OID4VCI  │                   │  :7001      │  │
+│  │  :8121 admin    │                   │  wallet-api │  │
+│  │  :8122 OID4VCI  │                   │  :7001      │  │
 │  └─────────────────┘                   └─────────────┘  │
 │                                              │           │
 │  ┌─────────────────┐     OID4VP v1           │           │
@@ -236,10 +236,10 @@ To issue a credential manually:
 
 ```bash
 # Get the credential config IDs
-curl -s http://localhost:8021/oid4vci/credential-supported/list | python3 -m json.tool
+curl -s http://localhost:8121/oid4vci/credential-supported/list | python3 -m json.tool
 
 # Create an offer (replace <did> and <config_id>)
-curl -s -X POST http://localhost:8021/oid4vci/exchange/create \
+curl -s -X POST http://localhost:8121/oid4vci/exchange/create \
   -H "Content-Type: application/json" \
   -d '{
     "supported_cred_id": "<config_id>",
@@ -258,7 +258,7 @@ curl -s -X POST http://localhost:8021/oid4vci/exchange/create \
 ```
 
 Then paste the `credential_offer` URL into the wallet at
-`http://localhost:7101`.
+`http://localhost:7201`.
 
 ---
 

--- a/oid4vc/demo/docker-compose.yml
+++ b/oid4vc/demo/docker-compose.yml
@@ -33,8 +33,8 @@ services:
         ACAPY_VERSION: 1.4.0
         ISOMDL_BRANCH: fix/python-build-system
     ports:
-      - "${ACAPY_ISSUER_ADMIN_PORT:-8021}:8021"
-      - "${ACAPY_ISSUER_OID4VCI_PORT:-8022}:8022"
+      - "${ACAPY_ISSUER_ADMIN_PORT:-8121}:8021"
+      - "${ACAPY_ISSUER_OID4VCI_PORT:-8122}:8022"
     environment:
       - AGENT_ENDPOINT=http://acapy-issuer:8020
       # OID4VCI_ENDPOINT is the URL embedded in credential offers.
@@ -203,7 +203,7 @@ services:
     environment:
       - PORT=7101
       # Must match the public-facing wallet URL so deep-links resolve correctly.
-      - NUXT_PUBLIC_ISSUER_CALLBACK_URL=${WALLET_PUBLIC_URL:-http://localhost:7101}
+      - NUXT_PUBLIC_ISSUER_CALLBACK_URL=${WALLET_PUBLIC_URL:-http://localhost:7201}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:7101"]
       interval: 10s
@@ -230,7 +230,7 @@ services:
   waltid-proxy:
     image: nginx:alpine
     ports:
-      - "${WALLET_PORT:-7101}:80"
+      - "${WALLET_PORT:-7201}:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     depends_on:

--- a/oid4vc/demo/playwright/demo.spec.ts
+++ b/oid4vc/demo/playwright/demo.spec.ts
@@ -200,15 +200,18 @@ test.describe('OID4VC mDOC Demo', () => {
     // ── Create credential offer ──
     const credentialSubject = {
       'org.iso.18013.5.1': {
-        given_name:         'Alice',
-        family_name:        'Holder',
-        birth_date:         '1990-06-15',
-        issuing_country:    'US',
-        issuing_authority:  'Demo DMV',
-        document_number:    'DL-DEMO-001',
-        issue_date:         new Date().toISOString().split('T')[0],
-        expiry_date:        new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)
-                              .toISOString().split('T')[0],
+        given_name:              'Alice',
+        family_name:             'Holder',
+        birth_date:              '1990-06-15',
+        issuing_country:         'US',
+        issuing_authority:       'Demo DMV',
+        document_number:         'DL-DEMO-001',
+        issue_date:              new Date().toISOString().split('T')[0],
+        expiry_date:             new Date(Date.now() + 365 * 24 * 60 * 60 * 1000)
+                                   .toISOString().split('T')[0],
+        // portrait and un_distinguishing_sign are required by ISO 18013-5.1
+        portrait:                'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+        un_distinguishing_sign:  'USA',
         driving_privileges: [
           { vehicle_category_code: 'C', issue_date: '2020-01-01', expiry_date: '2030-01-01' },
         ],

--- a/oid4vc/demo/presentation-flow.md
+++ b/oid4vc/demo/presentation-flow.md
@@ -1,0 +1,40 @@
+# OID4VP mDL Presentation Flow
+
+```mermaid
+sequenceDiagram
+    participant PW as Playwright Test
+    participant Verifier as ACA-Py Verifier<br/>(OID4VP)
+    participant Wallet as walt.id<br/>Wallet API
+    participant Issuer as ACA-Py Issuer<br/>(OID4VCI)
+
+    Note over PW,Issuer: Prerequisites — mDL credential already in wallet from issuance flow
+
+    PW->>Verifier: POST /oid4vp/presentation-definition<br/>{pres_def: mso_mdoc, fields: [given_name, family_name]}
+    Verifier-->>PW: pres_def_id
+
+    PW->>Verifier: POST /oid4vp/request<br/>{pres_def_id, vp_formats: {mso_mdoc}}
+    Verifier-->>PW: presentation_id + request_uri<br/>openid://?request_uri=http://acapy-verifier.local/...
+
+    PW->>Wallet: POST /exchange/resolvePresentationRequest<br/>body: request_uri (text/plain)
+    Wallet->>Verifier: GET request_uri → fetch signed JAR
+    Verifier-->>Wallet: signed request object (JWT)<br/>contains presentation_definition
+    Wallet-->>PW: resolved request string
+
+    PW->>Wallet: GET /wallet/{id}/credentials
+    Wallet-->>PW: [{id, doctype: org.iso.18013.5.1.mDL, ...}]
+
+    PW->>Wallet: GET /wallet/{id}/dids
+    Wallet-->>PW: [{did, default: true}]
+
+    PW->>Wallet: POST /exchange/usePresentationRequest<br/>{did, presentationRequest, selectedCredentials: [credId]}
+    Wallet->>Verifier: POST /oid4vp/response<br/>VP token (mso_mdoc DeviceResponse)
+    Verifier->>Issuer: (trust anchor already uploaded — offline cert verification)
+    Verifier-->>Wallet: 200 OK
+
+    loop Poll up to 20 × 1s
+        PW->>Verifier: GET /oid4vp/presentation/{id}
+        Verifier-->>PW: state
+    end
+
+    Verifier-->>PW: state: presentation-valid ✓
+```

--- a/oid4vc/demo/setup.sh
+++ b/oid4vc/demo/setup.sh
@@ -18,11 +18,21 @@
 #   WALLET_URL               default http://localhost:7101
 set -euo pipefail
 
+# Load .env from the same directory as this script so port overrides are honoured.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$SCRIPT_DIR/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$SCRIPT_DIR/.env"
+  set +a
+fi
+
 ISSUER_ADMIN="${ACAPY_ISSUER_ADMIN_URL:-http://localhost:8021}"
 VERIFIER_ADMIN="${ACAPY_VERIFIER_ADMIN_URL:-http://localhost:8031}"
-WALLET_URL="${WALLET_URL:-http://localhost:7101}"
+WALLET_URL="${WALTID_WALLET_URL:-${WALLET_URL:-http://localhost:7101}}"
 
 GREEN='\033[0;32m'
+RED='\033[0;31m'
 YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 RESET='\033[0m'
@@ -30,6 +40,7 @@ RESET='\033[0m'
 info()    { echo -e "${CYAN}[demo]${RESET} $*"; }
 success() { echo -e "${GREEN}[demo] ✓${RESET} $*"; }
 warn()    { echo -e "${YELLOW}[demo] !${RESET} $*"; }
+error()   { echo -e "${RED}[demo] ✗${RESET} $*"; }
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -58,6 +69,75 @@ post_json() {
 get_json() {
   curl -sf "$1"
 }
+
+# ── Check external endpoint reachability ─────────────────────────────────────
+#
+# If ISSUER_OID4VCI_ENDPOINT or VERIFIER_OID4VP_ENDPOINT is set to an
+# external tunnel (zrok, ngrok, …), verify each is actually live.  A dead
+# tunnel proxy typically returns an HTML error page instead of JSON.
+#
+# When a tunnel is stale the variable is automatically commented out in .env
+# and the affected container is restarted so all credential-offer and
+# presentation-request URLs embed the docker-internal hostname instead.  A
+# one-time .env.bak backup is created before editing.
+
+_check_and_restart_if_stale() {
+  # Usage: _check_and_restart_if_stale ENV_VAR SERVICE_NAME
+  local env_var="$1"
+  local service="$2"
+  local value="${!env_var:-}"
+
+  # Nothing to do when the variable is unset or already points to a local URL.
+  if [[ -z "$value" ]] || [[ "$value" == http://acapy-* ]] || [[ "$value" == http://localhost* ]]; then
+    return 0
+  fi
+
+  info "Checking external endpoint ${env_var}=${value}"
+
+  # Probe the root.  A live ACA-Py server returns JSON; a dead tunnel proxy
+  # (e.g. the zrok "tunnel not found" page) returns HTML.
+  local body
+  body=$(curl -s --max-time 5 "${value}/" 2>/dev/null) || body=""
+  local first_char
+  first_char=$(python3 -c "import sys; s=sys.stdin.read().strip(); print(s[:1] if s else '')" <<< "$body" 2>/dev/null) || first_char=""
+
+  if [[ -n "$first_char" && "$first_char" != "<" ]]; then
+    success "External endpoint is live: ${value}"
+    return 0
+  fi
+
+  warn "Tunnel ${value} is down (no response or HTML error page)."
+  warn "Commenting out ${env_var} in .env and restarting ${service} to use"
+  warn "the docker-internal hostname.  Backup saved as .env.bak (first time only)."
+
+  # Comment out the variable in .env using Python for cross-platform compat.
+  python3 - <<PYEOF
+import re, shutil, pathlib
+p = pathlib.Path("${SCRIPT_DIR}/.env")
+bak = p.parent / ".env.bak"
+if not bak.exists():
+    shutil.copy(p, bak)
+content = p.read_text()
+content = re.sub(
+    r'^(${env_var}=)',
+    r'# [auto-disabled: tunnel unreachable — re-enable when active] \1',
+    content,
+    flags=re.MULTILINE,
+)
+p.write_text(content)
+PYEOF
+
+  # Remove from the current shell so docker compose reads the updated .env.
+  unset "${env_var}"
+
+  # Recreate the container with the corrected environment.
+  info "Restarting ${service}…"
+  (cd "${SCRIPT_DIR}" && docker compose up -d --force-recreate "${service}")
+  success "${service} restarted — URLs will now use the docker-internal hostname."
+}
+
+_check_and_restart_if_stale ISSUER_OID4VCI_ENDPOINT  acapy-issuer
+_check_and_restart_if_stale VERIFIER_OID4VP_ENDPOINT acapy-verifier
 
 # ── Wait for services ─────────────────────────────────────────────────────────
 

--- a/oid4vc/docker/Dockerfile
+++ b/oid4vc/docker/Dockerfile
@@ -1,44 +1,112 @@
+# =============================================================================
+# Stage 0: Build isomdl-uniffi from source (Rust + maturin)
+# =============================================================================
+FROM python:3.12-slim-bookworm AS isomdl-builder
+
+# Install Rust toolchain dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust (stable)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Accept branch, tag, or commit ref to build from
+ARG ISOMDL_BRANCH=fix/python-build-system
+
+RUN git clone --depth 1 --branch "${ISOMDL_BRANCH}" \
+    https://github.com/Indicio-tech/isomdl-uniffi.git /build/isomdl-uniffi
+
+WORKDIR /build/isomdl-uniffi/python
+
+RUN pip install --no-cache-dir "maturin>=1.0,<2.0"
+RUN maturin build --release --out /build/dist
+
+# =============================================================================
+# Stage 1: Install ACA-Py and plugin dependencies
+# =============================================================================
 FROM python:3.12-slim-bookworm AS base
-WORKDIR /usr/src/app
-
-# Install and configure poetry
-USER root
-
-# Install and configure poetry
-WORKDIR /usr/src/app
-ENV POETRY_VERSION=2.1.2
-ENV POETRY_HOME=/opt/poetry
-RUN apt-get update && apt-get install -y curl jq && apt-get clean
-RUN curl -sSL https://install.python-poetry.org | python -
-
-ENV PATH="/opt/poetry/bin:$PATH"
-RUN poetry config virtualenvs.in-project true
-
-# Setup project
-RUN mkdir oid4vc && touch oid4vc/__init__.py
-RUN mkdir jwt_vc_json && touch jwt_vc_json/__init__.py
-RUN mkdir sd_jwt_vc && touch sd_jwt_vc/__init__.py
-RUN mkdir mso_mdoc && touch mso_mdoc/__init__.py
-COPY oid4vc/pyproject.toml oid4vc/poetry.lock oid4vc/README.md ./
-RUN poetry install --without dev --all-extras
-USER $user
-
-FROM python:3.12-bookworm
 
 WORKDIR /usr/src/app
-COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
-ENV PATH="/usr/src/app/.venv/bin:$PATH"
-RUN apt-get update && apt-get install -y curl jq && apt-get clean
+
+# Install only required build/runtime dependencies (no Rust needed here)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    jq \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Accept build argument for ACA-Py version
+ARG ACAPY_VERSION=1.4.0
+
+# Clone ACA-Py source with shallow clone
+RUN git clone --depth 1 --branch ${ACAPY_VERSION} \
+    https://github.com/openwallet-foundation/acapy.git /usr/src/acapy
+
+WORKDIR /usr/src/acapy
+
+# Install ACA-Py
+RUN pip install --no-cache-dir -e .
+RUN pip install --no-cache-dir configargparse
+
+# Setup plugin project structure
+WORKDIR /usr/src/app
+
+# Copy the entire plugin source tree
+COPY oid4vc/pyproject.toml ./
+COPY oid4vc/README.md ./
+COPY oid4vc/oid4vc/ oid4vc/
 COPY oid4vc/jwt_vc_json/ jwt_vc_json/
 COPY oid4vc/mso_mdoc/ mso_mdoc/
 COPY oid4vc/sd_jwt_vc/ sd_jwt_vc/
-COPY oid4vc/oid4vc/ oid4vc/
 COPY status_list/ status_list/
 RUN pip install -e ./status_list
+
+# Install isomdl-uniffi from locally built wheel
+COPY --from=isomdl-builder /build/dist/*.whl /tmp/isomdl/
+RUN pip install --no-cache-dir /tmp/isomdl/*.whl && rm -rf /tmp/isomdl
+
+# Install the plugin with extras for mso_mdoc and sd_jwt_vc
+RUN pip install --no-cache-dir -e ".[mso_mdoc,sd_jwt_vc]"
+
+# =============================================================================
+# Stage 3: Final slim runtime image
+# =============================================================================
+FROM python:3.12-slim-bookworm
+
+WORKDIR /usr/src/app
+
+# Copy the complete environment from base stage
+COPY --from=base /usr/src/acapy /usr/src/acapy
+COPY --from=base /usr/src/app /usr/src/app
+
+# Install only runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    jq \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the entire Python environment from base stage, including site-packages
+COPY --from=base /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
+COPY --from=base /usr/local/bin /usr/local/bin
+
+# Copy dev config
 RUN mkdir -p /usr/src/app/docker
 COPY oid4vc/docker/dev.yml /usr/src/app/docker/dev.yml
 COPY oid4vc/docker/dev-verifier.yml /usr/src/app/docker/dev-verifier.yml
-COPY oid4vc/docker/default.yml /usr/src/app/default.yml
+COPY oid4vc/docker/default.yml /usr/src/app/docker/default.yml
 
-ENTRYPOINT ["/bin/bash", "-c", "aca-py \"$@\"", "--"]
-CMD ["start", "--arg-file", "default.yml"]
+# Expose ports
+EXPOSE 8030 8031 8032
+
+# Add health check
+HEALTHCHECK --interval=10s --timeout=5s --retries=12 --start-period=60s \
+  CMD curl -f http://localhost:${ACAPY_ADMIN_PORT:-8021}/status/ready || exit 1
+
+# Set working directory and run ACA-Py
+WORKDIR /usr/src/acapy
+CMD ["python", "-m", "acapy_agent", "start", "--arg-file", "/usr/src/app/docker/dev.yml"]

--- a/oid4vc/docker/dev-verifier.yml
+++ b/oid4vc/docker/dev-verifier.yml
@@ -22,13 +22,11 @@ plugin:
   - sd_jwt_vc
   - mso_mdoc
 
-# OID4VC plugin configuration - Use different ports for OID4VCI and OID4VP servers
+# OID4VC plugin configuration - both OID4VCI and OID4VP routes served on the same port
 plugin-config-value:
   - oid4vci.host=0.0.0.0
-  - oid4vci.port=8033
-  - oid4vci.endpoint=${OID4VCI_ENDPOINT:-http://localhost:8033}
-  - oid4vp.host=0.0.0.0
-  - oid4vp.port=8032
+  - oid4vci.port=8032
+  - oid4vci.endpoint=${OID4VCI_ENDPOINT:-http://localhost:8032}
   - oid4vp.endpoint=${OID4VP_ENDPOINT:-http://localhost:8032}
 
 # Ledger configuration - use no-ledger for simple development


### PR DESCRIPTION
## Summary

Adds a fully self-contained local demo for mDOC credential issuance (OID4VCI) and presentation (OID4VP) using the walt.id web wallet.

## Changes

- **demo/docker-compose.yml** — ACA-Py issuer + verifier + walt.id wallet + nginx proxy stack
- **demo/setup.sh** — one-shot setup script; detects stale zrok/ngrok tunnels, auto-comments them out of `.env` and restarts the affected container so the demo works locally without any tunnel configuration
- **demo/.env.example** — port overrides and optional zrok tunnel configuration docs
- **demo/playwright/demo.spec.ts** — end-to-end Playwright tests: Issue mDL via OID4VCI + Present mDL credential via OID4VP (verifies `presentation-valid`)
- **demo/presentation-flow.md** — OID4VP mDL presentation sequence diagram
- **docker/Dockerfile** — isomdl_uniffi Rust build + mso_mdoc / sd_jwt_vc / oid4vc plugins
- **docker/dev-verifier.yml** — separate verifier agent config with OID4VP enabled

## Testing

```bash
cd oid4vc/demo
docker compose up -d
./setup.sh
cd playwright && npx playwright test
```

Both tests pass (Issue mDL via OID4VCI + Present mDL via OID4VP) on a fresh `docker compose down -v` run.

Signed-off-by: Adam Burdett <burdettadam@gmail.com>
