### PR TITLE
fix(demo): make mDL credential config creation idempotent

### DIFF
--- a/oid4vc/demo/setup.sh
+++ b/oid4vc/demo/setup.sh
@@ -204,8 +204,20 @@ print(json.dumps(config))
 PYEOF
 )
 
-MDL_RESP=$(post_json "$ISSUER_ADMIN/oid4vci/credential-supported/create" "$MDL_CONFIG")
-MDL_CRED_ID=$(echo "$MDL_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin)['supported_cred_id'])")
+MDL_CRED_ID=$(get_json "$ISSUER_ADMIN/oid4vci/credential-supported/records" | \
+  python3 -c "
+import json, sys
+records = json.load(sys.stdin).get('results', [])
+match = next((r['supported_cred_id'] for r in records if r.get('identifier') == '$MDL_CONFIG_ID'), '')
+print(match)
+" 2>/dev/null)
+
+if [[ -n "$MDL_CRED_ID" ]]; then
+  info "mDL credential config already exists, reusing it…"
+else
+  MDL_RESP=$(post_json "$ISSUER_ADMIN/oid4vci/credential-supported/create" "$MDL_CONFIG")
+  MDL_CRED_ID=$(echo "$MDL_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin)['supported_cred_id'])")
+fi
 success "mDL credential config: $MDL_CRED_ID"
 
 # ── Step 4: Store config for Playwright ──────────────────────────────────────


### PR DESCRIPTION
## Problem

`setup.sh` failed on re-runs with `400 Record with identifier org.iso.18013.5.1.mDL_demo already exists`.

The `credential-supported` GET endpoint (`/records/{id}`) expects a UUID (`supported_cred_id`), not the human-readable `identifier` string. So the existence check always returned 404, and the subsequent create call hit a 400.

## Fix

Query the list endpoint (`GET /oid4vci/credential-supported/records`) and filter by `identifier` field in Python. If a match is found, reuse that record's UUID. Otherwise, create fresh.

This makes `setup.sh` safely re-runnable without tearing down the stack.