### PR TITLE
build: point isomdl build to main branch

### DIFF
--- a/oid4vc/demo/docker-compose.yml
+++ b/oid4vc/demo/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       context: ../..
       args:
         ACAPY_VERSION: 1.4.0
-        ISOMDL_BRANCH: fix/python-build-system
+        ISOMDL_BRANCH: main
     ports:
       - "${ACAPY_ISSUER_ADMIN_PORT:-8121}:8021"
       - "${ACAPY_ISSUER_OID4VCI_PORT:-8122}:8022"
@@ -83,7 +83,7 @@ services:
       context: ../..
       args:
         ACAPY_VERSION: 1.4.0
-        ISOMDL_BRANCH: fix/python-build-system
+        ISOMDL_BRANCH: main
     ports:
       - "${ACAPY_VERIFIER_ADMIN_PORT:-8031}:8031"
       - "${ACAPY_VERIFIER_OID4VP_PORT:-8032}:8032"

--- a/oid4vc/docker/Dockerfile
+++ b/oid4vc/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Accept branch, tag, or commit ref to build from
-ARG ISOMDL_BRANCH=fix/python-build-system
+ARG ISOMDL_BRANCH=main
 
 RUN git clone --depth 1 --branch "${ISOMDL_BRANCH}" \
     https://github.com/Indicio-tech/isomdl-uniffi.git /build/isomdl-uniffi


### PR DESCRIPTION
## Summary

Updates `ISOMDL_BRANCH` from `fix/python-build-system` to `main` in both the Dockerfile default arg and the demo docker-compose build args.

The `fix/python-build-system` branch has been merged into `main` on [isomdl-uniffi](https://github.com/Indicio-tech/isomdl-uniffi), so builds should now pull from `main`.

## Changes
- `oid4vc/docker/Dockerfile`: `ARG ISOMDL_BRANCH=main`
- `oid4vc/demo/docker-compose.yml`: `ISOMDL_BRANCH: main` for both issuer and verifier services

## Testing
Verified end-to-end with the demo stack:
- ✅ mDL credential issuance via OID4VCI
- ✅ mDL presentation via OID4VP