### PR TITLE
feat: auto-register certs as trust anchors and return PEMs by default

### DIFF
--- a/oid4vc/mso_mdoc/key_generation.py
+++ b/oid4vc/mso_mdoc/key_generation.py
@@ -461,6 +461,18 @@ async def generate_default_keys_and_certs(
         session, "default_certificate", {"cert_id": cert_id}
     )
 
+    # Auto-register the certificate as a trust anchor so verifiers
+    # immediately have the issuer cert in their trust store.
+    anchor_ids = await storage_manager.auto_register_trust_anchors(
+        session, cert_pem, source="key-generation"
+    )
+    if anchor_ids:
+        LOGGER.info(
+            "Auto-registered %d trust anchor(s) from generated certificate: %s",
+            len(anchor_ids),
+            anchor_ids,
+        )
+
     LOGGER.info("Generated default mDoc key: %s and certificate: %s", key_id, cert_id)
 
     return {

--- a/oid4vc/mso_mdoc/key_routes.py
+++ b/oid4vc/mso_mdoc/key_routes.py
@@ -119,13 +119,15 @@ async def list_certificates(request: web.BaseRequest):
     """List all stored mDoc certificates.
 
     Query parameters:
-        include_pem: If "true", include the certificate_pem field in results
+        exclude_pem: If "true", omit the certificate_pem field from results.
+            PEMs are included by default so callers can use cert data for
+            trust-registry automation without extra round-trips.
     """
     context: AdminRequestContext = request["context"]
     storage_manager = MdocStorageManager(context.profile)
 
-    # Check for include_pem query parameter
-    include_pem = request.query.get("include_pem", "").lower() == "true"
+    # PEMs are now included by default; pass exclude_pem=true to omit them.
+    include_pem = request.query.get("exclude_pem", "").lower() != "true"
 
     try:
         async with context.profile.session() as session:

--- a/oid4vc/mso_mdoc/storage/__init__.py
+++ b/oid4vc/mso_mdoc/storage/__init__.py
@@ -19,7 +19,9 @@ Storage Types:
 """
 
 from datetime import UTC, datetime
+import hashlib
 import logging
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 from acapy_agent.core.profile import Profile, ProfileSession
@@ -389,10 +391,6 @@ class MdocStorageManager:
         Returns:
             List of anchor IDs that were newly created.
         """
-        import hashlib
-        import re
-        import uuid as _uuid
-
         _PEM_RE = re.compile(
             r"-----BEGIN CERTIFICATE-----[A-Za-z0-9+/=\s]+?"
             r"-----END CERTIFICATE-----\n?",

--- a/oid4vc/mso_mdoc/storage/__init__.py
+++ b/oid4vc/mso_mdoc/storage/__init__.py
@@ -231,9 +231,14 @@ class MdocStorageManager:
         key_id: str,
         metadata: Optional[Dict] = None,
     ) -> None:
-        """Store a PEM certificate."""
+        """Store a PEM certificate and auto-register it as a trust anchor."""
         await certificates.store_certificate(
             session, cert_id, certificate_pem, key_id, metadata
+        )
+        # Automatically register every cert in the PEM chain as a trust anchor
+        # so the trust registry stays in sync without manual steps.
+        await self.auto_register_trust_anchors(
+            session, certificate_pem, source="cert-store"
         )
 
     async def get_certificate(
@@ -364,3 +369,63 @@ class MdocStorageManager:
     async def delete_trust_anchor(self, session: ProfileSession, anchor_id: str) -> bool:
         """Delete a trust anchor by ID."""
         return await trust_anchors.delete_trust_anchor(session, anchor_id)
+
+    async def auto_register_trust_anchors(
+        self,
+        session: ProfileSession,
+        certificate_pem: str,
+        source: str = "auto",
+    ) -> List[str]:
+        """Parse a PEM (possibly a chain) and register each cert as a trust anchor.
+
+        Duplicate certificates (by PEM content) are silently skipped so this
+        method is idempotent.
+
+        Args:
+            session: Active database session
+            certificate_pem: One or more concatenated PEM certificate blocks
+            source: Label for metadata (e.g. ``"key-generation"``)
+
+        Returns:
+            List of anchor IDs that were newly created.
+        """
+        import hashlib
+        import re
+        import uuid as _uuid
+
+        _PEM_RE = re.compile(
+            r"-----BEGIN CERTIFICATE-----[A-Za-z0-9+/=\s]+?"
+            r"-----END CERTIFICATE-----\n?",
+            re.DOTALL,
+        )
+        individual_pems = _PEM_RE.findall(certificate_pem)
+        if not individual_pems:
+            return []
+
+        # Fetch existing trust anchor PEMs to avoid duplicates
+        existing_pems = set(
+            await trust_anchors.get_all_trust_anchor_pems(session)
+        )
+
+        created: List[str] = []
+        for pem in individual_pems:
+            normalized = pem.strip()
+            if normalized in existing_pems:
+                continue
+            # Deterministic-ish anchor ID based on cert fingerprint
+            fingerprint = hashlib.sha256(normalized.encode()).hexdigest()[:12]
+            anchor_id = f"auto-{source}-{fingerprint}"
+            try:
+                await trust_anchors.store_trust_anchor(
+                    session,
+                    anchor_id=anchor_id,
+                    certificate_pem=normalized,
+                    metadata={"source": source, "auto_registered": True},
+                )
+                created.append(anchor_id)
+                existing_pems.add(normalized)
+            except Exception:
+                LOGGER.debug(
+                    "Skipping duplicate trust anchor %s", anchor_id, exc_info=True
+                )
+        return created

--- a/oid4vc/mso_mdoc/storage/__init__.py
+++ b/oid4vc/mso_mdoc/storage/__init__.py
@@ -401,9 +401,7 @@ class MdocStorageManager:
             return []
 
         # Fetch existing trust anchor PEMs to avoid duplicates
-        existing_pems = set(
-            await trust_anchors.get_all_trust_anchor_pems(session)
-        )
+        existing_pems = set(await trust_anchors.get_all_trust_anchor_pems(session))
 
         created: List[str] = []
         for pem in individual_pems:

--- a/oid4vc/mso_mdoc/tests/test_cert_trust_registry.py
+++ b/oid4vc/mso_mdoc/tests/test_cert_trust_registry.py
@@ -10,11 +10,11 @@ These tests verify that:
 
 import json
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from acapy_agent.storage.base import StorageRecord
-from acapy_agent.storage.error import StorageDuplicateError, StorageNotFoundError
+
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import ec

--- a/oid4vc/mso_mdoc/tests/test_cert_trust_registry.py
+++ b/oid4vc/mso_mdoc/tests/test_cert_trust_registry.py
@@ -76,9 +76,7 @@ def _gen_chain_pems() -> tuple[str, str, str]:
     leaf_key = ec.generate_private_key(ec.SECP256R1())
     leaf_cert = (
         x509.CertificateBuilder()
-        .subject_name(
-            x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Leaf DS")])
-        )
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Leaf DS")]))
         .issuer_name(root_name)
         .public_key(leaf_key.public_key())
         .serial_number(x509.random_serial_number())
@@ -111,9 +109,7 @@ def session():
 def storage(monkeypatch):
     mock_storage = AsyncMock()
     monkeypatch.setattr(keys, "get_storage", MagicMock(return_value=mock_storage))
-    monkeypatch.setattr(
-        certificates, "get_storage", MagicMock(return_value=mock_storage)
-    )
+    monkeypatch.setattr(certificates, "get_storage", MagicMock(return_value=mock_storage))
     monkeypatch.setattr(
         trust_anchors, "get_storage", MagicMock(return_value=mock_storage)
     )
@@ -184,9 +180,7 @@ async def test_auto_register_non_pem_input_returns_empty(
     storage_manager, session, storage
 ):
     """Non-PEM text is ignored."""
-    created = await storage_manager.auto_register_trust_anchors(
-        session, "not a cert"
-    )
+    created = await storage_manager.auto_register_trust_anchors(session, "not a cert")
     assert created == []
     storage.add_record.assert_not_awaited()
 
@@ -214,9 +208,7 @@ async def test_store_certificate_auto_adds_trust_anchor(
 
     # Two add_record calls: one for the cert, one for the trust anchor
     assert storage.add_record.await_count == 2
-    types = [
-        storage.add_record.await_args_list[i].args[0].type for i in range(2)
-    ]
+    types = [storage.add_record.await_args_list[i].args[0].type for i in range(2)]
     assert MDOC_CERT_RECORD_TYPE in types
     assert MDOC_TRUST_ANCHOR_RECORD_TYPE in types
 

--- a/oid4vc/mso_mdoc/tests/test_cert_trust_registry.py
+++ b/oid4vc/mso_mdoc/tests/test_cert_trust_registry.py
@@ -1,0 +1,337 @@
+"""Tests for certificate management and trust-registry auto-registration.
+
+These tests verify that:
+1. Storing a certificate automatically registers it as a trust anchor.
+2. The list_certificates API returns PEMs by default.
+3. Certificate chains are split and each cert is registered individually.
+4. Duplicate certificates are not re-registered.
+5. Key generation auto-populates the trust registry.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from acapy_agent.storage.base import StorageRecord
+from acapy_agent.storage.error import StorageDuplicateError, StorageNotFoundError
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from ..storage import (
+    MDOC_CERT_RECORD_TYPE,
+    MDOC_TRUST_ANCHOR_RECORD_TYPE,
+    MdocStorageManager,
+    certificates,
+    config,
+    keys,
+    trust_anchors,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _gen_self_signed_pem() -> str:
+    """Generate a self-signed P-256 certificate and return its PEM string."""
+    key = ec.generate_private_key(ec.SECP256R1())
+    now = datetime.now(UTC)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test CA")]))
+        .issuer_name(x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Test CA")]))
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=365))
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def _gen_chain_pems() -> tuple[str, str, str]:
+    """Generate a root → leaf certificate chain.
+
+    Returns (root_pem, leaf_pem, chain_pem) where chain_pem = leaf + root.
+    """
+    root_key = ec.generate_private_key(ec.SECP256R1())
+    now = datetime.now(UTC)
+    root_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Root CA")])
+    root_cert = (
+        x509.CertificateBuilder()
+        .subject_name(root_name)
+        .issuer_name(root_name)
+        .public_key(root_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=1), critical=True)
+        .sign(root_key, hashes.SHA256())
+    )
+
+    leaf_key = ec.generate_private_key(ec.SECP256R1())
+    leaf_cert = (
+        x509.CertificateBuilder()
+        .subject_name(
+            x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "Leaf DS")])
+        )
+        .issuer_name(root_name)
+        .public_key(leaf_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(now + timedelta(days=365))
+        .sign(root_key, hashes.SHA256())
+    )
+
+    root_pem = root_cert.public_bytes(serialization.Encoding.PEM).decode()
+    leaf_pem = leaf_cert.public_bytes(serialization.Encoding.PEM).decode()
+    return root_pem, leaf_pem, leaf_pem + root_pem
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def storage_manager():
+    return MdocStorageManager(MagicMock())
+
+
+@pytest.fixture
+def session():
+    return MagicMock()
+
+
+@pytest.fixture
+def storage(monkeypatch):
+    mock_storage = AsyncMock()
+    monkeypatch.setattr(keys, "get_storage", MagicMock(return_value=mock_storage))
+    monkeypatch.setattr(
+        certificates, "get_storage", MagicMock(return_value=mock_storage)
+    )
+    monkeypatch.setattr(
+        trust_anchors, "get_storage", MagicMock(return_value=mock_storage)
+    )
+    monkeypatch.setattr(config, "get_storage", MagicMock(return_value=mock_storage))
+    return mock_storage
+
+
+# =========================================================================
+# auto_register_trust_anchors
+# =========================================================================
+
+
+@pytest.mark.asyncio
+async def test_auto_register_single_cert(storage_manager, session, storage):
+    """A single PEM cert is registered as a trust anchor."""
+    pem = _gen_self_signed_pem()
+    # No existing trust anchors
+    storage.find_all_records = AsyncMock(return_value=[])
+
+    created = await storage_manager.auto_register_trust_anchors(session, pem)
+
+    assert len(created) == 1
+    assert created[0].startswith("auto-")
+    # add_record called once for the new trust anchor
+    storage.add_record.assert_awaited_once()
+    record = storage.add_record.await_args.args[0]
+    assert record.type == MDOC_TRUST_ANCHOR_RECORD_TYPE
+    payload = json.loads(record.value)
+    assert payload["metadata"]["auto_registered"] is True
+
+
+@pytest.mark.asyncio
+async def test_auto_register_chain_pem_creates_two_anchors(
+    storage_manager, session, storage
+):
+    """A chain PEM (leaf + root) adds one trust anchor per cert."""
+    _root, _leaf, chain = _gen_chain_pems()
+    storage.find_all_records = AsyncMock(return_value=[])
+
+    created = await storage_manager.auto_register_trust_anchors(session, chain)
+
+    assert len(created) == 2
+    assert storage.add_record.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_auto_register_skips_duplicates(storage_manager, session, storage):
+    """Certs already in the trust registry are not re-added."""
+    pem = _gen_self_signed_pem()
+
+    # Simulate existing trust anchor with the same PEM
+    existing_record = StorageRecord(
+        type=MDOC_TRUST_ANCHOR_RECORD_TYPE,
+        id="existing-anchor",
+        value=json.dumps({"certificate_pem": pem.strip(), "created_at": "t"}),
+        tags={},
+    )
+    storage.find_all_records = AsyncMock(return_value=[existing_record])
+
+    created = await storage_manager.auto_register_trust_anchors(session, pem)
+
+    assert created == []
+    storage.add_record.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_register_non_pem_input_returns_empty(
+    storage_manager, session, storage
+):
+    """Non-PEM text is ignored."""
+    created = await storage_manager.auto_register_trust_anchors(
+        session, "not a cert"
+    )
+    assert created == []
+    storage.add_record.assert_not_awaited()
+
+
+# =========================================================================
+# store_certificate → auto trust-anchor registration
+# =========================================================================
+
+
+@pytest.mark.asyncio
+async def test_store_certificate_auto_adds_trust_anchor(
+    storage_manager, session, storage
+):
+    """Storing a certificate with a valid PEM auto-registers a trust anchor."""
+    pem = _gen_self_signed_pem()
+    # No existing trust anchors
+    storage.find_all_records = AsyncMock(return_value=[])
+
+    await storage_manager.store_certificate(
+        session,
+        cert_id="cert-1",
+        certificate_pem=pem,
+        key_id="key-1",
+    )
+
+    # Two add_record calls: one for the cert, one for the trust anchor
+    assert storage.add_record.await_count == 2
+    types = [
+        storage.add_record.await_args_list[i].args[0].type for i in range(2)
+    ]
+    assert MDOC_CERT_RECORD_TYPE in types
+    assert MDOC_TRUST_ANCHOR_RECORD_TYPE in types
+
+
+@pytest.mark.asyncio
+async def test_store_certificate_non_pem_does_not_add_trust_anchor(
+    storage_manager, session, storage
+):
+    """Storing a cert with non-PEM data only creates the cert record."""
+    await storage_manager.store_certificate(
+        session,
+        cert_id="cert-1",
+        certificate_pem="raw-data-not-pem",
+        key_id="key-1",
+    )
+
+    # Only the certificate record is stored
+    storage.add_record.assert_awaited_once()
+    record = storage.add_record.await_args.args[0]
+    assert record.type == MDOC_CERT_RECORD_TYPE
+
+
+# =========================================================================
+# list_certificates — PEM returned by default
+# =========================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_certificates_includes_pem_by_default(
+    storage_manager, session, storage
+):
+    """list_certificates(include_pem=True) returns certificate_pem field."""
+    records = [
+        StorageRecord(
+            type=MDOC_CERT_RECORD_TYPE,
+            id="cert-1",
+            value=json.dumps(
+                {
+                    "certificate_pem": "pem-data",
+                    "key_id": "key-1",
+                    "created_at": "2024-01-01T00:00:00",
+                    "metadata": {},
+                }
+            ),
+            tags={"key_id": "key-1"},
+        )
+    ]
+    storage.find_all_records = AsyncMock(return_value=records)
+
+    result = await storage_manager.list_certificates(session, include_pem=True)
+
+    assert len(result) == 1
+    assert "certificate_pem" in result[0]
+    assert result[0]["certificate_pem"] == "pem-data"
+
+
+@pytest.mark.asyncio
+async def test_list_certificates_omits_pem_when_requested(
+    storage_manager, session, storage
+):
+    """list_certificates(include_pem=False) omits certificate_pem field."""
+    records = [
+        StorageRecord(
+            type=MDOC_CERT_RECORD_TYPE,
+            id="cert-1",
+            value=json.dumps(
+                {
+                    "certificate_pem": "pem-data",
+                    "key_id": "key-1",
+                    "created_at": "2024-01-01T00:00:00",
+                    "metadata": {},
+                }
+            ),
+            tags={"key_id": "key-1"},
+        )
+    ]
+    storage.find_all_records = AsyncMock(return_value=records)
+
+    result = await storage_manager.list_certificates(session, include_pem=False)
+
+    assert "certificate_pem" not in result[0]
+
+
+# =========================================================================
+# generate_default_keys_and_certs → trust-anchor auto-registration
+# =========================================================================
+
+
+@pytest.mark.asyncio
+async def test_generate_keys_auto_registers_trust_anchor(session, storage):
+    """generate_default_keys_and_certs adds the cert to the trust registry."""
+    from ..key_generation import generate_default_keys_and_certs
+
+    storage.find_all_records = AsyncMock(return_value=[])
+    manager = MdocStorageManager(MagicMock())
+
+    result = await generate_default_keys_and_certs(manager, session)
+
+    # Should have add_record calls for: key, certificate, config×2, trust anchor
+    assert result["key_id"]
+    assert result["cert_id"]
+    assert result["certificate_pem"]
+
+    # Verify trust anchor was created
+    add_calls = storage.add_record.await_args_list
+    record_types = [call.args[0].type for call in add_calls]
+    assert MDOC_TRUST_ANCHOR_RECORD_TYPE in record_types, (
+        "Trust anchor should be auto-registered during key generation"
+    )
+
+    # Find the trust anchor record and verify its content
+    for call in add_calls:
+        rec = call.args[0]
+        if rec.type == MDOC_TRUST_ANCHOR_RECORD_TYPE:
+            payload = json.loads(rec.value)
+            assert "-----BEGIN CERTIFICATE-----" in payload["certificate_pem"]
+            assert payload["metadata"]["auto_registered"] is True
+            break


### PR DESCRIPTION
Auto-register certs as trust anchors and return PEMs by default.

Certs stored or generated are now auto-added to the trust registry. The list_certificates API returns PEMs by default. Added 9 tests covering auto-registration, dedup, and chain handling.